### PR TITLE
feature

### DIFF
--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -209,7 +209,7 @@
 &trans  &trans   &trans   &trans  &trans  &trans                        &bt BT_SEL 0            &bt BT_SEL 1        &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4  &trans   
 &trans  &kp F1   &kp F2   &kp F3  &kp F4  &kp F5                        &bt BT_CLR              &trans              &trans        &trans        &trans        &to MAC_DEF     
 &trans  &kp F6   &kp F7   &kp F8  &kp F9  &kp F10                       &trans                  &kp LEFT            &kp DOWN      &kp UP        &kp RIGHT     &trans
-&trans  &kp F11  &kp F12  &none   &none   &none    &trans       &trans  &none                   &none               &none         &none         &trans
+&trans  &kp F11  &kp F12  &none   &none   &none    &trans       &trans  &none                   &none               &none         &none         &trans        &trans
                           &none   &trans  &trans   &kp SPACE    &trans  &bm WIN_FUNC BACKSPACE  &kp LC(LEFT_SHIFT)  &trans
             >;
         };
@@ -242,7 +242,7 @@
 &trans  &trans   &trans   &trans  &trans  &trans                        &bt BT_SEL 0            &bt BT_SEL 1        &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4  &trans   
 &trans  &kp F1   &kp F2   &kp F3  &kp F4  &kp F5                        &bt BT_CLR              &trans              &trans        &trans        &trans        &to MAC_DEF     
 &trans  &kp F6   &kp F7   &kp F8  &kp F9  &kp F10                       &trans                  &kp LEFT            &kp DOWN      &kp UP        &kp RIGHT     &trans
-&trans  &kp F11  &kp F12  &none   &none   &none    &trans       &trans  &none                   &none               &none         &none         &trans
+&trans  &kp F11  &kp F12  &none   &none   &none    &trans       &trans  &none                   &none               &none         &none         &trans        &trans
                           &none   &trans  &trans   &kp SPACE    &trans  &bm WIN_FUNC BACKSPACE  &kp LC(LEFT_SHIFT)  &trans
             >;
         };

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -195,22 +195,22 @@
         windows_code_layer {
             label = "WinCode";
             bindings = <
-&trans  &trans               &trans  &trans                &trans          &trans                            &trans                  &trans              &trans     &trans                &trans                 &trans
-&trans  &kp EXCLAMATION      &kp AT  &kp HASH              &kp DOLLAR      &kp PERCENT                       &kp CARET               &kp AMPERSAND       &kp STAR   &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &trans
-&trans  &kp C_AL_CALCULATOR  &none   &kp NON_US_BACKSLASH  &kp MINUS       &kp EQUAL                         &kp GRAVE               &kp SINGLE_QUOTE    &kp COLON  &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &trans
-&trans  &trans               &none   &kp PIPE              &kp UNDERSCORE  &kp PLUS     &trans       &trans  &kp TILDE               &kp DOUBLE_QUOTES   &kp SLASH  &kp LEFT_BRACE        &kp RIGHT_BRACE        &trans
-                                     &none                 &trans          &trans       &kp SPACE    &trans  &bm WIN_FUNC BACKSPACE  &kp LC(LEFT_SHIFT)  &trans
+&trans  &trans               &trans  &trans                &trans          &trans                                        &trans                  &trans              &trans     &trans                &trans                 &trans
+&trans  &kp EXCLAMATION      &kp AT  &kp HASH              &kp DOLLAR      &kp PERCENT                                   &kp CARET               &kp AMPERSAND       &kp STAR   &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &trans
+&trans  &kp C_AL_CALCULATOR  &none   &kp NON_US_BACKSLASH  &kp MINUS       &kp EQUAL                                     &kp GRAVE               &kp SINGLE_QUOTE    &kp COLON  &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &trans
+&trans  &trans               &none   &kp PIPE              &kp UNDERSCORE  &kp PLUS     &kp LEFT_SHIFT    &kp BACKSPACE  &kp TILDE               &kp DOUBLE_QUOTES   &kp SLASH  &kp LEFT_BRACE        &kp RIGHT_BRACE        &trans
+                                     &none                 &kp LEFT_ALT    &trans       &kp SPACE         &kp ENTER      &bm WIN_FUNC BACKSPACE  &kp LC(LEFT_SHIFT)  &trans
             >;
         };
 
         windows_function_layer {
             label = "WinFunc";
             bindings = <
-&trans  &trans   &trans   &trans  &trans  &trans                        &bt BT_SEL 0            &bt BT_SEL 1        &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4  &trans   
-&trans  &kp F1   &kp F2   &kp F3  &kp F4  &kp F5                        &bt BT_CLR              &trans              &trans        &trans        &trans        &to MAC_DEF     
-&trans  &kp F6   &kp F7   &kp F8  &kp F9  &kp F10                       &trans                  &kp LEFT            &kp DOWN      &kp UP        &kp RIGHT     &trans
-&trans  &kp F11  &kp F12  &none   &none   &none    &trans       &trans  &none                   &none               &none         &none         &trans        &trans
-                          &none   &trans  &trans   &kp SPACE    &trans  &bm WIN_FUNC BACKSPACE  &kp LC(LEFT_SHIFT)  &trans
+&trans  &trans   &trans   &trans  &trans        &trans                                    &bt BT_SEL 0            &bt BT_SEL 1        &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4  &trans   
+&trans  &kp F1   &kp F2   &kp F3  &kp F4        &kp F5                                    &bt BT_CLR              &trans              &trans        &trans        &trans        &to MAC_DEF     
+&trans  &kp F6   &kp F7   &kp F8  &kp F9        &kp F10                                   &trans                  &kp LEFT            &kp DOWN      &kp UP        &kp RIGHT     &trans
+&trans  &kp F11  &kp F12  &none   &none         &none    &kp LEFT_SHIFT    &kp BACKSPACE  &none                   &none               &none         &none         &trans        &trans
+                          &none   &kp LEFT_ALT  &trans   &kp SPACE         &kp ENTER      &bm WIN_FUNC BACKSPACE  &kp LC(LEFT_SHIFT)  &trans
             >;
         };
 
@@ -228,22 +228,22 @@
         mac_code_layer {
             label = "MacCode";
             bindings = <
-&trans  &trans               &trans  &trans                &trans          &trans                            &trans                  &trans              &trans     &trans                &trans                 &trans
-&trans  &kp EXCLAMATION      &kp AT  &kp HASH              &kp DOLLAR      &kp PERCENT                       &kp CARET               &kp AMPERSAND       &kp STAR   &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &trans
-&trans  &kp C_AL_CALCULATOR  &none   &kp NON_US_BACKSLASH  &kp MINUS       &kp EQUAL                         &kp GRAVE               &kp SINGLE_QUOTE    &kp COLON  &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &trans
-&trans  &trans               &none   &kp PIPE              &kp UNDERSCORE  &kp PLUS     &trans       &trans  &kp TILDE               &kp DOUBLE_QUOTES   &kp SLASH  &kp LEFT_BRACE        &kp RIGHT_BRACE        &trans
-                                     &none                 &trans          &trans       &kp SPACE    &trans  &bm WIN_FUNC BACKSPACE  &kp LC(LEFT_SHIFT)  &trans
+&trans  &trans           &trans  &trans                &trans          &trans                                        &trans                  &trans              &trans     &trans                &trans                 &trans
+&trans  &kp EXCLAMATION  &kp AT  &kp HASH              &kp DOLLAR      &kp PERCENT                                   &kp CARET               &kp AMPERSAND       &kp STAR   &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &trans
+&trans  &sk GLOBE        &none   &kp NON_US_BACKSLASH  &kp MINUS       &kp EQUAL                                     &kp GRAVE               &kp SINGLE_QUOTE    &kp COLON  &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &trans
+&trans  &trans           &none   &kp PIPE              &kp UNDERSCORE  &kp PLUS     &kp LEFT_SHIFT    &kp BACKSPACE  &kp TILDE               &kp DOUBLE_QUOTES   &kp SLASH  &kp LEFT_BRACE        &kp RIGHT_BRACE        &trans
+                                 &kp LEFT_ALT          &kp LEFT_GUI    &trans       &kp SPACE         &kp ENTER      &bm WIN_FUNC BACKSPACE  &kp LC(LEFT_SHIFT)  &trans
             >;
         };
 
         mac_function_layer {
             label = "MacFunc";
             bindings = <
-&trans  &trans   &trans   &trans  &trans  &trans                        &bt BT_SEL 0            &bt BT_SEL 1        &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4  &trans   
-&trans  &kp F1   &kp F2   &kp F3  &kp F4  &kp F5                        &bt BT_CLR              &trans              &trans        &trans        &trans        &to WIN_DEF     
-&trans  &kp F6   &kp F7   &kp F8  &kp F9  &kp F10                       &trans                  &kp LEFT            &kp DOWN      &kp UP        &kp RIGHT     &trans
-&trans  &kp F11  &kp F12  &none   &none   &none    &trans       &trans  &none                   &none               &none         &none         &trans        &trans
-                          &none   &trans  &trans   &kp SPACE    &trans  &bm WIN_FUNC BACKSPACE  &kp LC(LEFT_SHIFT)  &trans
+&trans  &trans   &trans   &trans        &trans        &trans                                    &bt BT_SEL 0            &bt BT_SEL 1        &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4  &trans   
+&trans  &kp F1   &kp F2   &kp F3        &kp F4        &kp F5                                    &bt BT_CLR              &trans              &trans        &trans        &trans        &to WIN_DEF     
+&trans  &kp F6   &kp F7   &kp F8        &kp F9        &kp F10                                   &trans                  &kp LEFT            &kp DOWN      &kp UP        &kp RIGHT     &trans
+&trans  &kp F11  &kp F12  &none         &none         &none    &kp LEFT_SHIFT    &kp BACKSPACE  &none                   &none               &none         &none         &trans        &trans
+                          &kp LEFT_ALT  &kp LEFT_GUI  &trans   &kp SPACE         &kp ENTER      &bm MAC_FUNC BACKSPACE  &kp LC(LEFT_SHIFT)  &trans
             >;
         };
     };

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -221,7 +221,7 @@
 &kp TAB           &kp Q   &kp W   &kp E         &kp R         &kp T                                          &kp Y                   &kp U               &kp I      &kp O    &kp P          &kp DELETE
 &td_multi_mac     &kp A   &kp S   &kp D         &kp F         &kp G                                          &kp H                   &kp J               &kp K      &kp L    &kp SEMICOLON  &kp LC(TAB)
 &kp LEFT_CONTROL  &kp Z   &kp X   &kp C         &kp V         &kp B         &kp LEFT_SHIFT    &kp BACKSPACE  &kp N                   &kp M               &kp COMMA  &kp DOT  &kp SLASH      &kp ESC
-                                  &kp LEFT_ALT  &kp LEFT_GUI  &mo WIN_CODE  &kp SPACE         &kp ENTER      &bm WIN_FUNC BACKSPACE  &kp LC(LEFT_SHIFT)  &kp LC(TAB)
+                                  &kp LEFT_ALT  &kp LEFT_GUI  &mo MAC_CODE  &kp SPACE         &kp ENTER      &bm MAC_FUNC BACKSPACE  &kp LC(LEFT_SHIFT)  &kp LC(TAB)
             >;
         };
 
@@ -240,7 +240,7 @@
             label = "MacFunc";
             bindings = <
 &trans  &trans   &trans   &trans  &trans  &trans                        &bt BT_SEL 0            &bt BT_SEL 1        &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4  &trans   
-&trans  &kp F1   &kp F2   &kp F3  &kp F4  &kp F5                        &bt BT_CLR              &trans              &trans        &trans        &trans        &to MAC_DEF     
+&trans  &kp F1   &kp F2   &kp F3  &kp F4  &kp F5                        &bt BT_CLR              &trans              &trans        &trans        &trans        &to WIN_DEF     
 &trans  &kp F6   &kp F7   &kp F8  &kp F9  &kp F10                       &trans                  &kp LEFT            &kp DOWN      &kp UP        &kp RIGHT     &trans
 &trans  &kp F11  &kp F12  &none   &none   &none    &trans       &trans  &none                   &none               &none         &none         &trans        &trans
                           &none   &trans  &trans   &kp SPACE    &trans  &bm WIN_FUNC BACKSPACE  &kp LC(LEFT_SHIFT)  &trans

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -206,44 +206,44 @@
         windows_function_layer {
             label = "WinFunc";
             bindings = <
-&trans  &trans   &trans   &trans  &trans  &trans                         &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4  &trans   
-&trans  &kp F1   &kp F2   &kp F3  &kp F4  &kp F5                         &bt BT_CLR    &trans        &trans        &trans        &trans        &to MAC_DEF     
-&trans  &kp F6   &kp F7   &kp F8  &kp F9  &kp F10                        &trans        &kp LEFT      &kp DOWN      &kp UP        &kp RIGHT     &trans
-&trans  &kp F11  &kp F12  &none   &none   &none    &trans        &trans  &none         &none         &none         &none         &trans
-                          &none   &trans  &trans   &kp SPACE     &trans  &trans        &kp LC(LEFT_SHIFT)          &trans
+&trans  &trans   &trans   &trans  &trans  &trans                        &bt BT_SEL 0            &bt BT_SEL 1        &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4  &trans   
+&trans  &kp F1   &kp F2   &kp F3  &kp F4  &kp F5                        &bt BT_CLR              &trans              &trans        &trans        &trans        &to MAC_DEF     
+&trans  &kp F6   &kp F7   &kp F8  &kp F9  &kp F10                       &trans                  &kp LEFT            &kp DOWN      &kp UP        &kp RIGHT     &trans
+&trans  &kp F11  &kp F12  &none   &none   &none    &trans       &trans  &none                   &none               &none         &none         &trans
+                          &none   &trans  &trans   &kp SPACE    &trans  &bm WIN_FUNC BACKSPACE  &kp LC(LEFT_SHIFT)  &trans
             >;
         };
 
         mac_default_layer {
             label = "MacOS";
             bindings = <
-&kp ESC           &kp N1  &kp N2  &kp N3    &kp N4    &kp N5                                   &kp N6  &kp N7    &kp N8              &kp N9   &kp N0    &kp GRAVE
-&kp TAB           &kp Q   &kp W   &kp E     &kp R     &kp T                                    &kp Y   &kp U     &kp I               &kp O    &kp P     &kp MINUS
-&kp LEFT_SHIFT    &kp A   &kp S   &kp D     &kp F     &kp G                                    &kp H   &kp J     &kp K               &kp L    &kp SEMI  &kp SQT
-&kp LEFT_CONTROL  &kp Z   &kp X   &kp C     &kp V     &kp B   &kp LEFT_SHIFT    &kp BACKSPACE  &kp N   &kp M     &kp COMMA           &kp DOT  &kp FSLH  &kp RSHFT
-                                  &kp LALT  &kp LGUI  &mo 1   &kp SPACE         &kp RET        &mo 2   &kp BSPC  &kp LC(LEFT_SHIFT)
+&kp ESC           &kp N1  &kp N2  &kp N3        &kp N4        &kp N5                                         &kp N6                  &kp N7              &kp N8     &kp N9   &kp N0         &kp GRAVE
+&kp TAB           &kp Q   &kp W   &kp E         &kp R         &kp T                                          &kp Y                   &kp U               &kp I      &kp O    &kp P          &kp DELETE
+&td_multi_mac     &kp A   &kp S   &kp D         &kp F         &kp G                                          &kp H                   &kp J               &kp K      &kp L    &kp SEMICOLON  &kp LC(TAB)
+&kp LEFT_CONTROL  &kp Z   &kp X   &kp C         &kp V         &kp B         &kp LEFT_SHIFT    &kp BACKSPACE  &kp N                   &kp M               &kp COMMA  &kp DOT  &kp SLASH      &kp ESC
+                                  &kp LEFT_ALT  &kp LEFT_GUI  &mo WIN_CODE  &kp SPACE         &kp ENTER      &bm WIN_FUNC BACKSPACE  &kp LC(LEFT_SHIFT)  &kp LC(TAB)
             >;
         };
 
         mac_code_layer {
             label = "MacCode";
             bindings = <
-&kp GRAVE  &kp EXCLAMATION  &kp AT_SIGN  &kp HASH  &kp DOLLAR      &kp PERCENT                    &kp CARET  &kp AMPERSAND      &kp ASTERISK  &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp NON_US_BACKSLASH
-&trans     &trans           &trans       &trans    &kp MINUS       &kp EQUAL                      &kp GRAVE  &kp SINGLE_QUOTE   &kp COLON     &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp PIPE
-&trans     &trans           &trans       &trans    &kp UNDERSCORE  &kp PLUS                       &kp TILDE  &kp DOUBLE_QUOTES  &kp SLASH     &kp LEFT_BRACE        &kp RIGHT_BRACE        &kp PERIOD
-&trans     &trans           &trans       &trans    &trans          &trans       &trans    &trans  &trans     &trans             &trans        &trans                &trans                 &trans
-                                         &trans    &trans          &trans       &trans    &trans  &trans     &trans             &trans
+&trans  &trans               &trans  &trans                &trans          &trans                            &trans                  &trans              &trans     &trans                &trans                 &trans
+&trans  &kp EXCLAMATION      &kp AT  &kp HASH              &kp DOLLAR      &kp PERCENT                       &kp CARET               &kp AMPERSAND       &kp STAR   &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &trans
+&trans  &kp C_AL_CALCULATOR  &none   &kp NON_US_BACKSLASH  &kp MINUS       &kp EQUAL                         &kp GRAVE               &kp SINGLE_QUOTE    &kp COLON  &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &trans
+&trans  &trans               &none   &kp PIPE              &kp UNDERSCORE  &kp PLUS     &trans       &trans  &kp TILDE               &kp DOUBLE_QUOTES   &kp SLASH  &kp LEFT_BRACE        &kp RIGHT_BRACE        &trans
+                                     &none                 &trans          &trans       &kp SPACE    &trans  &bm WIN_FUNC BACKSPACE  &kp LC(LEFT_SHIFT)  &trans
             >;
         };
 
         mac_function_layer {
             label = "MacFunc";
             bindings = <
-&bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4  &bt BT_CLR                    &trans  &trans    &trans    &trans  &trans     &trans
-&trans        &trans        &trans        &trans        &trans        &trans                        &trans  &trans    &trans    &trans  &trans     &trans
-&kp F1        &kp F2        &kp F3        &kp F4        &kp F5        &kp F6                        &trans  &kp LEFT  &kp DOWN  &kp UP  &kp RIGHT  &trans
-&kp F7        &kp F8        &kp F9        &kp F10       &kp F11       &kp F12     &trans    &trans  &trans  &trans    &trans    &trans  &trans     &trans
-                                          &trans        &trans        &trans      &trans    &trans  &trans  &trans    &trans
+&trans  &trans   &trans   &trans  &trans  &trans                        &bt BT_SEL 0            &bt BT_SEL 1        &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4  &trans   
+&trans  &kp F1   &kp F2   &kp F3  &kp F4  &kp F5                        &bt BT_CLR              &trans              &trans        &trans        &trans        &to MAC_DEF     
+&trans  &kp F6   &kp F7   &kp F8  &kp F9  &kp F10                       &trans                  &kp LEFT            &kp DOWN      &kp UP        &kp RIGHT     &trans
+&trans  &kp F11  &kp F12  &none   &none   &none    &trans       &trans  &none                   &none               &none         &none         &trans
+                          &none   &trans  &trans   &kp SPACE    &trans  &bm WIN_FUNC BACKSPACE  &kp LC(LEFT_SHIFT)  &trans
             >;
         };
     };

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -199,7 +199,7 @@
 &trans  &kp EXCLAMATION      &kp AT  &kp HASH              &kp DOLLAR      &kp PERCENT                                   &kp CARET               &kp AMPERSAND       &kp STAR   &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &trans
 &trans  &kp C_AL_CALCULATOR  &none   &kp NON_US_BACKSLASH  &kp MINUS       &kp EQUAL                                     &kp GRAVE               &kp SINGLE_QUOTE    &kp COLON  &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &trans
 &trans  &trans               &none   &kp PIPE              &kp UNDERSCORE  &kp PLUS     &kp LEFT_SHIFT    &kp BACKSPACE  &kp TILDE               &kp DOUBLE_QUOTES   &kp SLASH  &kp LEFT_BRACE        &kp RIGHT_BRACE        &trans
-                                     &none                 &kp LEFT_ALT    &trans       &kp SPACE         &kp ENTER      &bm WIN_FUNC BACKSPACE  &kp LC(LEFT_SHIFT)  &trans
+                                     &none                 &kp LEFT_ALT    &trans       &kp SPACE         &kp ENTER      &bm WIN_FUNC BACKSPACE  &kp LC(LEFT_SHIFT)  &kp LC(TAB)
             >;
         };
 
@@ -210,7 +210,7 @@
 &trans  &kp F1   &kp F2   &kp F3  &kp F4        &kp F5                                    &bt BT_CLR              &trans              &trans        &trans        &trans        &to MAC_DEF     
 &trans  &kp F6   &kp F7   &kp F8  &kp F9        &kp F10                                   &trans                  &kp LEFT            &kp DOWN      &kp UP        &kp RIGHT     &trans
 &trans  &kp F11  &kp F12  &none   &none         &none    &kp LEFT_SHIFT    &kp BACKSPACE  &none                   &none               &none         &none         &trans        &trans
-                          &none   &kp LEFT_ALT  &trans   &kp SPACE         &kp ENTER      &bm WIN_FUNC BACKSPACE  &kp LC(LEFT_SHIFT)  &trans
+                          &none   &kp LEFT_ALT  &trans   &kp SPACE         &kp ENTER      &bm WIN_FUNC BACKSPACE  &kp LC(LEFT_SHIFT)  &kp LC(TAB)
             >;
         };
 
@@ -232,7 +232,7 @@
 &trans  &kp EXCLAMATION  &kp AT  &kp HASH              &kp DOLLAR      &kp PERCENT                                   &kp CARET               &kp AMPERSAND       &kp STAR   &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &trans
 &trans  &sk GLOBE        &none   &kp NON_US_BACKSLASH  &kp MINUS       &kp EQUAL                                     &kp GRAVE               &kp SINGLE_QUOTE    &kp COLON  &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &trans
 &trans  &trans           &none   &kp PIPE              &kp UNDERSCORE  &kp PLUS     &kp LEFT_SHIFT    &kp BACKSPACE  &kp TILDE               &kp DOUBLE_QUOTES   &kp SLASH  &kp LEFT_BRACE        &kp RIGHT_BRACE        &trans
-                                 &kp LEFT_ALT          &kp LEFT_GUI    &trans       &kp SPACE         &kp ENTER      &bm WIN_FUNC BACKSPACE  &kp LC(LEFT_SHIFT)  &trans
+                                 &kp LEFT_ALT          &kp LEFT_GUI    &trans       &kp SPACE         &kp ENTER      &bm WIN_FUNC BACKSPACE  &kp LC(LEFT_SHIFT)  &kp LC(TAB)
             >;
         };
 
@@ -243,7 +243,7 @@
 &trans  &kp F1   &kp F2   &kp F3        &kp F4        &kp F5                                    &bt BT_CLR              &trans              &trans        &trans        &trans        &to WIN_DEF     
 &trans  &kp F6   &kp F7   &kp F8        &kp F9        &kp F10                                   &trans                  &kp LEFT            &kp DOWN      &kp UP        &kp RIGHT     &trans
 &trans  &kp F11  &kp F12  &none         &none         &none    &kp LEFT_SHIFT    &kp BACKSPACE  &none                   &none               &none         &none         &trans        &trans
-                          &kp LEFT_ALT  &kp LEFT_GUI  &trans   &kp SPACE         &kp ENTER      &bm MAC_FUNC BACKSPACE  &kp LC(LEFT_SHIFT)  &trans
+                          &kp LEFT_ALT  &kp LEFT_GUI  &trans   &kp SPACE         &kp ENTER      &bm MAC_FUNC BACKSPACE  &kp LC(LEFT_SHIFT)  &kp LC(TAB)
             >;
         };
     };

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -8,73 +8,29 @@
 #include <dt-bindings/zmk/bt.h>
 #include <dt-bindings/zmk/keys.h>
 
+// Layers
+
+#define WIN_DEF  0
+#define WIN_CODE 1
+#define WIN_FUNC 2
+#define MAC_DEF  3
+#define MAC_CODE 4
+#define MAC_FUNC 5
+
 / {
-    combos {
-        compatible = "zmk,combos";
-
-        combo_DEL {
-            bindings = <&kp DEL>;
-            key-positions = <10 11>;
-        };
-    };
-
     macros {
-        SPOTLIGHT: SPOTLIGHT {
+        terminal_win: terminal_win {
+            label = "TERMINAL_WIN";
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
             bindings =
                 <&macro_press>,
-                <&kp LEFT_GUI>,
-                <&macro_wait_time 50>,
-                <&macro_tap>,
-                <&kp SPACE>,
-                <&macro_release>,
-                <&kp LEFT_GUI>;
-
-            label = "SPOTLIGHT";
-        };
-
-        SCREENSHOT_WIN: SCREENSHOT_WIN {
-            compatible = "zmk,behavior-macro";
-            #binding-cells = <0>;
-            bindings =
-                <&macro_press>,
-                <&kp LEFT_SHIFT &kp LEFT_GUI>,
-                <&macro_wait_time 50>,
-                <&macro_tap>,
-                <&kp S>,
-                <&macro_release>,
-                <&kp LEFT_SHIFT &kp LEFT_GUI>;
-
-            label = "SCREENSHOT_WIN";
-        };
-
-        SCREENSHOT_MAC: SCREENSHOT_MAC {
-            compatible = "zmk,behavior-macro";
-            #binding-cells = <0>;
-            bindings =
-                <&macro_press>,
-                <&kp LEFT_GUI &kp LEFT_SHIFT &kp LEFT_CONTROL>,
-                <&macro_wait_time 50>,
-                <&macro_tap>,
-                <&kp NUMBER_4>,
-                <&macro_release>,
-                <&kp LEFT_GUI &kp LEFT_SHIFT &kp LEFT_CONTROL>;
-
-            label = "SCREENSHOT_MAC";
-        };
-
-        TERMINAL_WIN: TERMINAL_WIN {
-            compatible = "zmk,behavior-macro";
-            #binding-cells = <0>;
-            bindings =
-                <&macro_press>,
-                <&kp LEFT_GUI>,
+                <&kp LGUI>,
                 <&macro_wait_time 50>,
                 <&macro_tap>,
                 <&kp R>,
                 <&macro_release>,
-                <&kp LEFT_GUI>,
+                <&kp LGUI>,
                 <&macro_wait_time 50>,
                 <&macro_tap>,
                 <&kp BACKSPACE>,
@@ -84,16 +40,100 @@
                 <&macro_wait_time 50>,
                 <&macro_tap>,
                 <&kp ENTER>;
+        };
 
-            label = "TERMINAL_WIN";
+        screenshot_win: screenshot_win {
+            label = "SCREENSHOT_WIN";
+            compatible = "zmk,behavior-macro";
+            #binding-cells = <0>;
+            bindings =
+                <&macro_press>,
+                <&kp LGUI &kp LEFT_SHIFT>,
+                <&macro_wait_time 50>,
+                <&macro_tap>,
+                <&kp S>,
+                <&macro_release>,
+                <&kp LGUI &kp LEFT_SHIFT>;
+        };
+
+        spotlight: spotlight {
+            label = "SPOTLIGHT";
+            compatible = "zmk,behavior-macro";
+            #binding-cells = <0>;
+            bindings =
+                <&macro_press>,
+                <&kp LGUI>,
+                <&macro_wait_time 50>,
+                <&macro_tap>,
+                <&kp SPACE>,
+                <&macro_release>,
+                <&kp LGUI>;
+        };
+
+        screenshot_mac: screenshot_mac {
+            label = "SCREEMSHOT_MAC";
+            compatible = "zmk,behavior-macro";
+            #binding-cells = <0>;
+            bindings =
+                <&macro_press>,
+                <&kp LGUI &kp LEFT_SHIFT &kp LEFT_CONTROL>,
+                <&macro_wait_time 50>,
+                <&macro_tap>,
+                <&kp NUMBER_4>,
+                <&macro_release>,
+                <&kp LGUI &kp LEFT_SHIFT &kp LEFT_CONTROL>;
+        };
+    };
+
+    combos {
+        compatible = "zmk,combos";
+
+        combo_TD_MULTI_WIN {
+            bindings = <&td_multi_win>;
+            key-positions = <13 14>;
+            layers = <0 1 2 3>;
+            timeout-ms = <150>;
+        };
+
+        combo_TD_MULTI_MAC {
+            bindings = <&td_multi_mac>;
+            key-positions = <13 14>;
+            layers = <4 5 6 7>;
+            timeout-ms = <150>;
+        };
+
+        combo_ESC {
+            bindings = <&kp ESC>;
+            key-positions = <1 2 3>;
+            timeout-ms = <200>;
+        };
+
+        combo_DEL {
+            bindings = <&kp DEL>;
+            key-positions = <9 10>;
+            timeout-ms = <200>;
+        };
+
+        combo_TAB {
+            bindings = <&kp TAB>;
+            key-positions = <1 2>;
+            timeout-ms = <200>;
+            layers = <0 1 2 3 4 5 6 7>;
+        };
+
+        combo_ALT {
+            bindings = <&sk LEFT_ALT>;
+            key-positions = <33 34>;
+            timeout-ms = <150>;
+            layers = <4 5 6 7>;
         };
     };
 
     keymap {
         compatible = "zmk,keymap";
 
-        default_layer {
-            label = "Base";
+        windows_default_layer {
+            label = "Windows";
             bindings = <
 &kp ESC           &kp N1  &kp N2  &kp N3    &kp N4    &kp N5                                   &kp N6  &kp N7    &kp N8              &kp N9   &kp N0    &kp GRAVE
 &kp TAB           &kp Q   &kp W   &kp E     &kp R     &kp T                                    &kp Y   &kp U     &kp I               &kp O    &kp P     &kp MINUS
@@ -103,8 +143,8 @@
             >;
         };
 
-        lower_layer {
-            label = "Lower";
+        windows_code_layer {
+            label = "WinCode";
             bindings = <
 &kp GRAVE  &kp EXCLAMATION  &kp AT_SIGN  &kp HASH  &kp DOLLAR      &kp PERCENT                    &kp CARET  &kp AMPERSAND      &kp ASTERISK  &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp NON_US_BACKSLASH
 &trans     &trans           &trans       &trans    &kp MINUS       &kp EQUAL                      &kp GRAVE  &kp SINGLE_QUOTE   &kp COLON     &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp PIPE
@@ -114,8 +154,41 @@
             >;
         };
 
-        raise_layer {
-            label = "Raise";
+        windows_function_layer {
+            label = "WinFunc";
+            bindings = <
+&bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4  &bt BT_CLR                    &trans  &trans    &trans    &trans  &trans     &trans
+&trans        &trans        &trans        &trans        &trans        &trans                        &trans  &trans    &trans    &trans  &trans     &trans
+&kp F1        &kp F2        &kp F3        &kp F4        &kp F5        &kp F6                        &trans  &kp LEFT  &kp DOWN  &kp UP  &kp RIGHT  &trans
+&kp F7        &kp F8        &kp F9        &kp F10       &kp F11       &kp F12     &trans    &trans  &trans  &trans    &trans    &trans  &trans     &trans
+                                          &trans        &trans        &trans      &trans    &trans  &trans  &trans    &trans
+            >;
+        };
+
+        mac_default_layer {
+            label = "MacOS";
+            bindings = <
+&kp ESC           &kp N1  &kp N2  &kp N3    &kp N4    &kp N5                                   &kp N6  &kp N7    &kp N8              &kp N9   &kp N0    &kp GRAVE
+&kp TAB           &kp Q   &kp W   &kp E     &kp R     &kp T                                    &kp Y   &kp U     &kp I               &kp O    &kp P     &kp MINUS
+&kp LEFT_SHIFT    &kp A   &kp S   &kp D     &kp F     &kp G                                    &kp H   &kp J     &kp K               &kp L    &kp SEMI  &kp SQT
+&kp LEFT_CONTROL  &kp Z   &kp X   &kp C     &kp V     &kp B   &kp LEFT_SHIFT    &kp BACKSPACE  &kp N   &kp M     &kp COMMA           &kp DOT  &kp FSLH  &kp RSHFT
+                                  &kp LALT  &kp LGUI  &mo 1   &kp SPACE         &kp RET        &mo 2   &kp BSPC  &kp LC(LEFT_SHIFT)
+            >;
+        };
+
+        mac_code_layer {
+            label = "MacCode";
+            bindings = <
+&kp GRAVE  &kp EXCLAMATION  &kp AT_SIGN  &kp HASH  &kp DOLLAR      &kp PERCENT                    &kp CARET  &kp AMPERSAND      &kp ASTERISK  &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp NON_US_BACKSLASH
+&trans     &trans           &trans       &trans    &kp MINUS       &kp EQUAL                      &kp GRAVE  &kp SINGLE_QUOTE   &kp COLON     &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp PIPE
+&trans     &trans           &trans       &trans    &kp UNDERSCORE  &kp PLUS                       &kp TILDE  &kp DOUBLE_QUOTES  &kp SLASH     &kp LEFT_BRACE        &kp RIGHT_BRACE        &kp PERIOD
+&trans     &trans           &trans       &trans    &trans          &trans       &trans    &trans  &trans     &trans             &trans        &trans                &trans                 &trans
+                                         &trans    &trans          &trans       &trans    &trans  &trans     &trans             &trans
+            >;
+        };
+
+        mac_function_layer {
+            label = "MacFunc";
             bindings = <
 &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4  &bt BT_CLR                    &trans  &trans    &trans    &trans  &trans     &trans
 &trans        &trans        &trans        &trans        &trans        &trans                        &trans  &trans    &trans    &trans  &trans     &trans

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -184,11 +184,11 @@
         windows_default_layer {
             label = "Windows";
             bindings = <
-&kp ESC           &kp N1  &kp N2  &kp N3        &kp N4        &kp N5                                         &kp N6                  &kp N7              &kp N8     &kp N9   &kp N0         &kp GRAVE
-&kp TAB           &kp Q   &kp W   &kp E         &kp R         &kp T                                          &kp Y                   &kp U               &kp I      &kp O    &kp P          &kp DELETE
-&td_multi_win     &kp A   &kp S   &kp D         &kp F         &kp G                                          &kp H                   &kp J               &kp K      &kp L    &kp SEMICOLON  &kp LC(TAB)
-&kp LEFT_CONTROL  &kp Z   &kp X   &kp C         &kp V         &kp B         &kp LEFT_SHIFT    &kp BACKSPACE  &kp N                   &kp M               &kp COMMA  &kp DOT  &kp SLASH      &kp ESC
-                                                &kp LEFT_ALT  &mo WIN_CODE  &kp SPACE         &kp ENTER      &bm WIN_FUNC BACKSPACE  &kp LC(LEFT_SHIFT)
+&kp ESC           &kp N1  &kp N2  &kp N3  &kp N4        &kp N5                                         &kp N6                  &kp N7              &kp N8     &kp N9   &kp N0         &kp GRAVE
+&kp TAB           &kp Q   &kp W   &kp E   &kp R         &kp T                                          &kp Y                   &kp U               &kp I      &kp O    &kp P          &kp DELETE
+&td_multi_win     &kp A   &kp S   &kp D   &kp F         &kp G                                          &kp H                   &kp J               &kp K      &kp L    &kp SEMICOLON  &kp LC(TAB)
+&kp LEFT_CONTROL  &kp Z   &kp X   &kp C   &kp V         &kp B         &kp LEFT_SHIFT    &kp BACKSPACE  &kp N                   &kp M               &kp COMMA  &kp DOT  &kp SLASH      &kp ESC
+                                  &none   &kp LEFT_ALT  &mo WIN_CODE  &kp SPACE         &kp ENTER      &bm WIN_FUNC BACKSPACE  &kp LC(LEFT_SHIFT)  &kp LC(TAB)
             >;
         };
 
@@ -199,18 +199,18 @@
 &trans  &kp EXCLAMATION      &kp AT  &kp HASH              &kp DOLLAR      &kp PERCENT                       &kp CARET               &kp AMPERSAND       &kp STAR   &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &trans
 &trans  &kp C_AL_CALCULATOR  &none   &kp NON_US_BACKSLASH  &kp MINUS       &kp EQUAL                         &kp GRAVE               &kp SINGLE_QUOTE    &kp COLON  &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &trans
 &trans  &trans               &none   &kp PIPE              &kp UNDERSCORE  &kp PLUS     &trans       &trans  &kp TILDE               &kp DOUBLE_QUOTES   &kp SLASH  &kp LEFT_BRACE        &kp RIGHT_BRACE        &trans
-                                                           &trans          &trans       &mo SPACE    &trans  &bm WIN_FUNC BACKSPACE  &kp LC(LEFT_SHIFT)
+                                     &none                 &trans          &trans       &kp SPACE    &trans  &bm WIN_FUNC BACKSPACE  &kp LC(LEFT_SHIFT)  &trans
             >;
         };
 
         windows_function_layer {
             label = "WinFunc";
             bindings = <
-&bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4  &bt BT_CLR                    &trans  &trans    &trans    &trans  &trans     &trans
-&trans        &trans        &trans        &trans        &trans        &trans                        &trans  &trans    &trans    &trans  &trans     &trans
-&kp F1        &kp F2        &kp F3        &kp F4        &kp F5        &kp F6                        &trans  &kp LEFT  &kp DOWN  &kp UP  &kp RIGHT  &trans
-&kp F7        &kp F8        &kp F9        &kp F10       &kp F11       &kp F12     &trans    &trans  &trans  &trans    &trans    &trans  &trans     &trans
-                                          &trans        &trans        &trans      &trans    &trans  &trans  &trans    &trans
+&trans  &trans   &trans   &trans  &trans  &trans                         &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4  &trans   
+&trans  &kp F1   &kp F2   &kp F3  &kp F4  &kp F5                         &bt BT_CLR    &trans        &trans        &trans        &to GAME_DEF  &to MAC_DEF     
+&trans  &kp F6   &kp F7   &kp F8  &kp F9  &kp F10                        &trans        &kp LEFT      &kp DOWN      &kp UP        &kp RIGHT     &trans
+&trans  &kp F11  &kp F12  &none   &none   &none    &trans        &trans  &none         &none         &none         &none         &trans
+                          &none   &trans  &trans   &kp SPACE     &trans  &trans        &kp LC(LEFT_SHIFT)          &trans
             >;
         };
 

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -87,46 +87,6 @@
 
     combos {
         compatible = "zmk,combos";
-
-        combo_TD_MULTI_WIN {
-            bindings = <&td_multi_win>;
-            key-positions = <13 14>;
-            layers = <0 1 2 3>;
-            timeout-ms = <150>;
-        };
-
-        combo_TD_MULTI_MAC {
-            bindings = <&td_multi_mac>;
-            key-positions = <13 14>;
-            layers = <4 5 6 7>;
-            timeout-ms = <150>;
-        };
-
-        combo_ESC {
-            bindings = <&kp ESC>;
-            key-positions = <1 2 3>;
-            timeout-ms = <200>;
-        };
-
-        combo_DEL {
-            bindings = <&kp DEL>;
-            key-positions = <9 10>;
-            timeout-ms = <200>;
-        };
-
-        combo_TAB {
-            bindings = <&kp TAB>;
-            key-positions = <1 2>;
-            timeout-ms = <200>;
-            layers = <0 1 2 3 4 5 6 7>;
-        };
-
-        combo_ALT {
-            bindings = <&sk LEFT_ALT>;
-            key-positions = <33 34>;
-            timeout-ms = <150>;
-            layers = <4 5 6 7>;
-        };
     };
 
     behaviors {
@@ -154,6 +114,7 @@
             quick-tap-ms = <0>;
             flavor = "tap-preferred";
             bindings = <&kp>, <&kp>;
+
             retro-tap;
         };
 
@@ -184,10 +145,10 @@
         windows_default_layer {
             label = "Windows";
             bindings = <
-&kp ESC           &kp N1  &kp N2  &kp N3  &kp N4        &kp N5                                         &kp N6                  &kp N7              &kp N8     &kp N9   &kp N0         &kp GRAVE
-&kp TAB           &kp Q   &kp W   &kp E   &kp R         &kp T                                          &kp Y                   &kp U               &kp I      &kp O    &kp P          &kp DELETE
-&td_multi_win     &kp A   &kp S   &kp D   &kp F         &kp G                                          &kp H                   &kp J               &kp K      &kp L    &kp SEMICOLON  &kp LC(TAB)
-&kp LEFT_CONTROL  &kp Z   &kp X   &kp C   &kp V         &kp B         &kp LEFT_SHIFT    &kp BACKSPACE  &kp N                   &kp M               &kp COMMA  &kp DOT  &kp SLASH      &kp ESC
+&kp ESC           &kp N1  &kp N2  &kp N3  &kp N4        &kp N5                                         &kp N6                  &kp N7              &kp N8       &kp N9   &kp N0         &kp GRAVE
+&kp TAB           &kp Q   &kp W   &kp E   &kp R         &kp T                                          &kp Y                   &kp U               &kp I        &kp O    &kp P          &kp DELETE
+&td_multi_win     &kp A   &kp S   &kp D   &kp F         &kp G                                          &kp H                   &kp J               &kp K        &kp L    &kp SEMICOLON  &kp LC(TAB)
+&kp LEFT_CONTROL  &kp Z   &kp X   &kp C   &kp V         &kp B         &kp LEFT_SHIFT    &kp BACKSPACE  &kp N                   &kp M               &kp COMMA    &kp DOT  &kp SLASH      &kp ESC
                                   &none   &kp LEFT_ALT  &mo WIN_CODE  &kp SPACE         &kp ENTER      &bm WIN_FUNC BACKSPACE  &kp LC(LEFT_SHIFT)  &kp LC(TAB)
             >;
         };
@@ -195,10 +156,10 @@
         windows_code_layer {
             label = "WinCode";
             bindings = <
-&trans  &trans               &trans  &trans                &trans          &trans                                        &trans                  &trans              &trans     &trans                &trans                 &trans
-&trans  &kp EXCLAMATION      &kp AT  &kp HASH              &kp DOLLAR      &kp PERCENT                                   &kp CARET               &kp AMPERSAND       &kp STAR   &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &trans
-&trans  &kp C_AL_CALCULATOR  &none   &kp NON_US_BACKSLASH  &kp MINUS       &kp EQUAL                                     &kp GRAVE               &kp SINGLE_QUOTE    &kp COLON  &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &trans
-&trans  &trans               &none   &kp PIPE              &kp UNDERSCORE  &kp PLUS     &kp LEFT_SHIFT    &kp BACKSPACE  &kp TILDE               &kp DOUBLE_QUOTES   &kp SLASH  &kp LEFT_BRACE        &kp RIGHT_BRACE        &trans
+&trans  &trans               &trans  &trans                &trans          &trans                                        &trans                  &trans              &trans       &trans                &trans                 &trans
+&trans  &kp EXCLAMATION      &kp AT  &kp HASH              &kp DOLLAR      &kp PERCENT                                   &kp CARET               &kp AMPERSAND       &kp STAR     &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &trans
+&trans  &kp C_AL_CALCULATOR  &none   &kp NON_US_BACKSLASH  &kp MINUS       &kp EQUAL                                     &kp GRAVE               &kp SINGLE_QUOTE    &kp COLON    &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &trans
+&trans  &trans               &none   &kp PIPE              &kp UNDERSCORE  &kp PLUS     &kp LEFT_SHIFT    &kp BACKSPACE  &kp TILDE               &kp DOUBLE_QUOTES   &kp SLASH    &kp LEFT_BRACE        &kp RIGHT_BRACE        &trans
                                      &none                 &kp LEFT_ALT    &trans       &kp SPACE         &kp ENTER      &bm WIN_FUNC BACKSPACE  &kp LC(LEFT_SHIFT)  &kp LC(TAB)
             >;
         };
@@ -206,8 +167,8 @@
         windows_function_layer {
             label = "WinFunc";
             bindings = <
-&trans  &trans   &trans   &trans  &trans        &trans                                    &bt BT_SEL 0            &bt BT_SEL 1        &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4  &trans   
-&trans  &kp F1   &kp F2   &kp F3  &kp F4        &kp F5                                    &bt BT_CLR              &trans              &trans        &trans        &trans        &to MAC_DEF     
+&trans  &trans   &trans   &trans  &trans        &trans                                    &bt BT_SEL 0            &bt BT_SEL 1        &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4  &trans
+&trans  &kp F1   &kp F2   &kp F3  &kp F4        &kp F5                                    &bt BT_CLR              &trans              &trans        &trans        &trans        &to MAC_DEF
 &trans  &kp F6   &kp F7   &kp F8  &kp F9        &kp F10                                   &trans                  &kp LEFT            &kp DOWN      &kp UP        &kp RIGHT     &trans
 &trans  &kp F11  &kp F12  &none   &none         &none    &kp LEFT_SHIFT    &kp BACKSPACE  &none                   &none               &none         &none         &trans        &trans
                           &none   &kp LEFT_ALT  &trans   &kp SPACE         &kp ENTER      &bm WIN_FUNC BACKSPACE  &kp LC(LEFT_SHIFT)  &kp LC(TAB)
@@ -217,10 +178,10 @@
         mac_default_layer {
             label = "MacOS";
             bindings = <
-&kp ESC           &kp N1  &kp N2  &kp N3        &kp N4        &kp N5                                         &kp N6                  &kp N7              &kp N8     &kp N9   &kp N0         &kp GRAVE
-&kp TAB           &kp Q   &kp W   &kp E         &kp R         &kp T                                          &kp Y                   &kp U               &kp I      &kp O    &kp P          &kp DELETE
-&td_multi_mac     &kp A   &kp S   &kp D         &kp F         &kp G                                          &kp H                   &kp J               &kp K      &kp L    &kp SEMICOLON  &kp LC(TAB)
-&kp LEFT_CONTROL  &kp Z   &kp X   &kp C         &kp V         &kp B         &kp LEFT_SHIFT    &kp BACKSPACE  &kp N                   &kp M               &kp COMMA  &kp DOT  &kp SLASH      &kp ESC
+&kp ESC           &kp N1  &kp N2  &kp N3        &kp N4        &kp N5                                         &kp N6                  &kp N7              &kp N8       &kp N9   &kp N0         &kp GRAVE
+&kp TAB           &kp Q   &kp W   &kp E         &kp R         &kp T                                          &kp Y                   &kp U               &kp I        &kp O    &kp P          &kp DELETE
+&td_multi_mac     &kp A   &kp S   &kp D         &kp F         &kp G                                          &kp H                   &kp J               &kp K        &kp L    &kp SEMICOLON  &kp LC(TAB)
+&kp LEFT_CONTROL  &kp Z   &kp X   &kp C         &kp V         &kp B         &kp LEFT_SHIFT    &kp BACKSPACE  &kp N                   &kp M               &kp COMMA    &kp DOT  &kp SLASH      &kp ESC
                                   &kp LEFT_ALT  &kp LEFT_GUI  &mo MAC_CODE  &kp SPACE         &kp ENTER      &bm MAC_FUNC BACKSPACE  &kp LC(LEFT_SHIFT)  &kp LC(TAB)
             >;
         };
@@ -228,10 +189,10 @@
         mac_code_layer {
             label = "MacCode";
             bindings = <
-&trans  &trans           &trans  &trans                &trans          &trans                                        &trans                  &trans              &trans     &trans                &trans                 &trans
-&trans  &kp EXCLAMATION  &kp AT  &kp HASH              &kp DOLLAR      &kp PERCENT                                   &kp CARET               &kp AMPERSAND       &kp STAR   &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &trans
-&trans  &sk GLOBE        &none   &kp NON_US_BACKSLASH  &kp MINUS       &kp EQUAL                                     &kp GRAVE               &kp SINGLE_QUOTE    &kp COLON  &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &trans
-&trans  &trans           &none   &kp PIPE              &kp UNDERSCORE  &kp PLUS     &kp LEFT_SHIFT    &kp BACKSPACE  &kp TILDE               &kp DOUBLE_QUOTES   &kp SLASH  &kp LEFT_BRACE        &kp RIGHT_BRACE        &trans
+&trans  &trans           &trans  &trans                &trans          &trans                                        &trans                  &trans              &trans       &trans                &trans                 &trans
+&trans  &kp EXCLAMATION  &kp AT  &kp HASH              &kp DOLLAR      &kp PERCENT                                   &kp CARET               &kp AMPERSAND       &kp STAR     &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &trans
+&trans  &sk GLOBE        &none   &kp NON_US_BACKSLASH  &kp MINUS       &kp EQUAL                                     &kp GRAVE               &kp SINGLE_QUOTE    &kp COLON    &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &trans
+&trans  &trans           &none   &kp PIPE              &kp UNDERSCORE  &kp PLUS     &kp LEFT_SHIFT    &kp BACKSPACE  &kp TILDE               &kp DOUBLE_QUOTES   &kp SLASH    &kp LEFT_BRACE        &kp RIGHT_BRACE        &trans
                                  &kp LEFT_ALT          &kp LEFT_GUI    &trans       &kp SPACE         &kp ENTER      &bm WIN_FUNC BACKSPACE  &kp LC(LEFT_SHIFT)  &kp LC(TAB)
             >;
         };
@@ -239,8 +200,8 @@
         mac_function_layer {
             label = "MacFunc";
             bindings = <
-&trans  &trans   &trans   &trans        &trans        &trans                                    &bt BT_SEL 0            &bt BT_SEL 1        &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4  &trans   
-&trans  &kp F1   &kp F2   &kp F3        &kp F4        &kp F5                                    &bt BT_CLR              &trans              &trans        &trans        &trans        &to WIN_DEF     
+&trans  &trans   &trans   &trans        &trans        &trans                                    &bt BT_SEL 0            &bt BT_SEL 1        &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4  &trans
+&trans  &kp F1   &kp F2   &kp F3        &kp F4        &kp F5                                    &bt BT_CLR              &trans              &trans        &trans        &trans        &to WIN_DEF
 &trans  &kp F6   &kp F7   &kp F8        &kp F9        &kp F10                                   &trans                  &kp LEFT            &kp DOWN      &kp UP        &kp RIGHT     &trans
 &trans  &kp F11  &kp F12  &none         &none         &none    &kp LEFT_SHIFT    &kp BACKSPACE  &none                   &none               &none         &none         &trans        &trans
                           &kp LEFT_ALT  &kp LEFT_GUI  &trans   &kp SPACE         &kp ENTER      &bm MAC_FUNC BACKSPACE  &kp LC(LEFT_SHIFT)  &kp LC(TAB)

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -129,28 +129,77 @@
         };
     };
 
+    behaviors {
+        td_multi_win: tap_dance_multi_win {
+            compatible = "zmk,behavior-tap-dance";
+            label = "TAP_DANCE_MULTI_WIN";
+            #binding-cells = <0>;
+            tapping-term-ms = <300>;
+            bindings = <&sk LEFT_GUI>, <&terminal_win>, <&screenshot_win>;
+        };
+
+        td_multi_mac: tap_dance_multi_mac {
+            compatible = "zmk,behavior-tap-dance";
+            label = "TAP_DANCE_MULTI_MAC";
+            #binding-cells = <0>;
+            tapping-term-ms = <300>;
+            bindings = <&kp LEFT_GUI>, <&spotlight>, <&screenshot_mac>;
+        };
+
+        cm: code_row_mods {
+            compatible = "zmk,behavior-hold-tap";
+            label = "CODE_ROW_MODS";
+            #binding-cells = <2>;
+            tapping-term-ms = <200>;
+            quick-tap-ms = <0>;
+            flavor = "tap-preferred";
+            bindings = <&kp>, <&kp>;
+            retro-tap;
+        };
+
+        bm: bspc_mod {
+            compatible = "zmk,behavior-hold-tap";
+            label = "BSPC_MOD";
+            #binding-cells = <2>;
+            tapping-term-ms = <250>;
+            quick-tap-ms = <200>;
+            flavor = "balanced";
+            bindings = <&mo>, <&kp>;
+        };
+
+        sm: space_mod {
+            compatible = "zmk,behavior-hold-tap";
+            label = "SPACE_MOD";
+            #binding-cells = <2>;
+            tapping-term-ms = <250>;
+            quick-tap-ms = <200>;
+            flavor = "balanced";
+            bindings = <&kp>, <&kp>;
+        };
+    };
+
     keymap {
         compatible = "zmk,keymap";
 
         windows_default_layer {
             label = "Windows";
             bindings = <
-&kp ESC           &kp N1  &kp N2  &kp N3    &kp N4    &kp N5                                   &kp N6  &kp N7    &kp N8              &kp N9   &kp N0    &kp GRAVE
-&kp TAB           &kp Q   &kp W   &kp E     &kp R     &kp T                                    &kp Y   &kp U     &kp I               &kp O    &kp P     &kp MINUS
-&kp LEFT_SHIFT    &kp A   &kp S   &kp D     &kp F     &kp G                                    &kp H   &kp J     &kp K               &kp L    &kp SEMI  &kp SQT
-&kp LEFT_CONTROL  &kp Z   &kp X   &kp C     &kp V     &kp B   &kp LEFT_SHIFT    &kp BACKSPACE  &kp N   &kp M     &kp COMMA           &kp DOT  &kp FSLH  &kp RSHFT
-                                  &kp LALT  &kp LGUI  &mo 1   &kp SPACE         &kp RET        &mo 2   &kp BSPC  &kp LC(LEFT_SHIFT)
+&kp ESC           &kp N1  &kp N2  &kp N3        &kp N4        &kp N5                                         &kp N6                  &kp N7              &kp N8     &kp N9   &kp N0         &kp GRAVE
+&kp TAB           &kp Q   &kp W   &kp E         &kp R         &kp T                                          &kp Y                   &kp U               &kp I      &kp O    &kp P          &kp DELETE
+&td_multi_win     &kp A   &kp S   &kp D         &kp F         &kp G                                          &kp H                   &kp J               &kp K      &kp L    &kp SEMICOLON  &kp LC(TAB)
+&kp LEFT_CONTROL  &kp Z   &kp X   &kp C         &kp V         &kp B         &kp LEFT_SHIFT    &kp BACKSPACE  &kp N                   &kp M               &kp COMMA  &kp DOT  &kp SLASH      &kp ESC
+                                                &kp LEFT_ALT  &mo WIN_CODE  &kp SPACE         &kp ENTER      &bm WIN_FUNC BACKSPACE  &kp LC(LEFT_SHIFT)
             >;
         };
 
         windows_code_layer {
             label = "WinCode";
             bindings = <
-&kp GRAVE  &kp EXCLAMATION  &kp AT_SIGN  &kp HASH  &kp DOLLAR      &kp PERCENT                    &kp CARET  &kp AMPERSAND      &kp ASTERISK  &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &kp NON_US_BACKSLASH
-&trans     &trans           &trans       &trans    &kp MINUS       &kp EQUAL                      &kp GRAVE  &kp SINGLE_QUOTE   &kp COLON     &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &kp PIPE
-&trans     &trans           &trans       &trans    &kp UNDERSCORE  &kp PLUS                       &kp TILDE  &kp DOUBLE_QUOTES  &kp SLASH     &kp LEFT_BRACE        &kp RIGHT_BRACE        &kp PERIOD
-&trans     &trans           &trans       &trans    &trans          &trans       &trans    &trans  &trans     &trans             &trans        &trans                &trans                 &trans
-                                         &trans    &trans          &trans       &trans    &trans  &trans     &trans             &trans
+&trans  &trans               &trans  &trans                &trans          &trans                            &trans                  &trans              &trans     &trans                &trans                 &trans
+&trans  &kp EXCLAMATION      &kp AT  &kp HASH              &kp DOLLAR      &kp PERCENT                       &kp CARET               &kp AMPERSAND       &kp STAR   &kp LEFT_PARENTHESIS  &kp RIGHT_PARENTHESIS  &trans
+&trans  &kp C_AL_CALCULATOR  &none   &kp NON_US_BACKSLASH  &kp MINUS       &kp EQUAL                         &kp GRAVE               &kp SINGLE_QUOTE    &kp COLON  &kp LEFT_BRACKET      &kp RIGHT_BRACKET      &trans
+&trans  &trans               &none   &kp PIPE              &kp UNDERSCORE  &kp PLUS     &trans       &trans  &kp TILDE               &kp DOUBLE_QUOTES   &kp SLASH  &kp LEFT_BRACE        &kp RIGHT_BRACE        &trans
+                                                           &trans          &trans       &mo SPACE    &trans  &bm WIN_FUNC BACKSPACE  &kp LC(LEFT_SHIFT)
             >;
         };
 

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -127,16 +127,6 @@
             flavor = "balanced";
             bindings = <&mo>, <&kp>;
         };
-
-        sm: space_mod {
-            compatible = "zmk,behavior-hold-tap";
-            label = "SPACE_MOD";
-            #binding-cells = <2>;
-            tapping-term-ms = <250>;
-            quick-tap-ms = <200>;
-            flavor = "balanced";
-            bindings = <&kp>, <&kp>;
-        };
     };
 
     keymap {

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -207,7 +207,7 @@
             label = "WinFunc";
             bindings = <
 &trans  &trans   &trans   &trans  &trans  &trans                         &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4  &trans   
-&trans  &kp F1   &kp F2   &kp F3  &kp F4  &kp F5                         &bt BT_CLR    &trans        &trans        &trans        &to GAME_DEF  &to MAC_DEF     
+&trans  &kp F1   &kp F2   &kp F3  &kp F4  &kp F5                         &bt BT_CLR    &trans        &trans        &trans        &trans        &to MAC_DEF     
 &trans  &kp F6   &kp F7   &kp F8  &kp F9  &kp F10                        &trans        &kp LEFT      &kp DOWN      &kp UP        &kp RIGHT     &trans
 &trans  &kp F11  &kp F12  &none   &none   &none    &trans        &trans  &none         &none         &none         &none         &trans
                           &none   &trans  &trans   &kp SPACE     &trans  &trans        &kp LC(LEFT_SHIFT)          &trans


### PR DESCRIPTION
- 調整鍵盤layer層,分開MAC與WINDOWS
- 功能: 更新 Windows 代碼的按鍵映射和綁定
- 功能: 更新`config/lily58.keymap`和`windows_function_layer`中的按鍵綁定和標籤
- 功能：更新Lily58鍵盤的按鍵映射和綁定
- 功能：更新`lily58`和`mac_code_layer`配置的按鍵綁定
- 重構：更新Lily58鍵盤的按鍵映射配置
- 事務：更新按鍵映射和按鍵綁定
- 事務：更新特殊字符的鍵綁定
- 功能：更新lily58键盘的按键映射配置和按键绑定
- 取消combo
- 翻譯：
