### PR TITLE
特性: 重構 `lily58` 鍵盤佈局的按鍵綁定

### DIFF
--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -196,11 +196,11 @@
         Windows_default_layer {
             display-name = "Windows";
             bindings = <
-&kp ESC           &kp N1  &kp N2  &kp N3    &kp N4    &kp N5                                                         &kp N6              &kp N7  &kp N8     &kp N9   &kp N0    &kp MINUS
-&kp TAB           &kp Q   &kp W   &kp E     &kp R     &kp T                                                          &kp Y               &kp U   &kp I      &kp O    &kp P     &kp DELETE
-&kp LEFT_CONTROL  &kp A   &kp S   &kp D     &kp F     &kp G                                                          &kp H               &kp J   &kp K      &kp L    &kp SEMI  &kp LC(TAB)
-&kp LEFT_CONTROL  &kp Z   &kp X   &kp C     &kp V     &kp B                   &tmux_list              &terminal_win  &kp N               &kp M   &kp COMMA  &kp DOT  &kp FSLH  &screenshot_win
-                                  &kp LALT  &kp LGUI  &lt WIN_CODE LCTRL RET  &lt WIN_FUNC BACKSPACE  &kp TAB        &kp LC(LEFT_SHIFT)
+&kp ESC           &kp N1  &kp N2  &kp N3    &kp N4    &kp N5                                                        &kp N6                  &kp N7   &kp N8              &kp N9   &kp N0    &kp MINUS
+&kp TAB           &kp Q   &kp W   &kp E     &kp R     &kp T                                                         &kp Y                   &kp U    &kp I               &kp O    &kp P     &kp DELETE
+&kp LEFT_CONTROL  &kp A   &kp S   &kp D     &kp F     &kp G                                                         &kp H                   &kp J    &kp K               &kp L    &kp SEMI  &kp LC(TAB)
+&kp LEFT_CONTROL  &kp Z   &kp X   &kp C     &kp V     &kp B                  &tmux_list              &terminal_win  &kp N                   &kp M    &kp COMMA           &kp DOT  &kp FSLH  &screenshot_win
+                                  &kp LALT  &kp LGUI  &lt WIN_CODE LCTRL RET &sm LEFT_SHIFT SPACE    &sm LCTRL RET  &lt WIN_FUNC BACKSPACE  &kp TAB  &kp LC(LEFT_SHIFT)
             >;
         };
 


### PR DESCRIPTION
- 更新 `lily58` 鍵盤佈局的按鍵圖
- 新增 `LEFT_SHIFT SPACE` 和 `LCTRL RET` 的功能
- 移除多餘的按鍵綁定並更新 `LC(LEFT_SHIFT)` 的使用

Signed-off-by: HomePC <jackie@dast.tw>
