### PR TITLE
功能: 重新配置新按鍵綁定的按鍵映射

### DIFF
--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -29,7 +29,7 @@
                 <&macro_release>,
                 <&kp LWIN>,
                 <&macro_tap>,
-                <&kp W &kp T &kp RET>;
+                <&kp BSPC &kp W &kp T &kp RET>;
 
             label = "TERMINAL";
         };


### PR DESCRIPTION
- 更新按鍵映射配置，將 `BSPC` 鍵添加在 `W T RET` 組合鍵之前

Signed-off-by: OfficePC <jackie@dast.tw>
