### PR TITLE
feat: consolidate keyboard shortcut modifications

### DIFF
--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -69,7 +69,7 @@
                 <&kp LWIN>,
                 <&macro_pause_for_release>,
                 <&macro_tap>,
-                <&kp W &kp T>,
+                <&kp W &kp E &kp Z &kp T &kp E &kp R &kp M &kp MINUS &kp G &kp U &kp I>,
                 <&macro_tap>,
                 <&kp RET>;
         };


### PR DESCRIPTION
- Add a long key combination for '⎋' on line 71

Signed-off-by: HomePC-WSL <jackie@dast.tw>
