### PR TITLE
feat: refactor key bindings in Lily58 keyboard firmware

### DIFF
--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -222,7 +222,7 @@
 &kp ESC    &kp N1  &kp N2  &kp N3    &kp N4    &kp N5                                             &kp N6           &kp N7   &kp N8         &kp N9   &kp N0    &kp MINUS
 &kp TAB    &kp Q   &kp W   &kp E     &kp R     &kp T                                              &kp Y            &kp U    &kp I          &kp O    &kp P     &kp LC(TAB)
 &kp LCTRL  &kp A   &kp S   &kp D     &kp F     &kp G                                              &kp H            &kp J    &kp K          &kp L    &kp SEMI  &kp LC(TAB)
-&kp LCTRL  &kp Z   &kp X   &kp C     &kp V     &kp B            &kp LC(LS(N2))     &ter_win       &kp N            &kp M    &kp COMMA      &kp DOT  &kp FSLH  &kp DEL
+&kp LCTRL  &kp Z   &kp X   &kp C     &kp V     &kp B            &kp LC(LG(D))     &ter_win       &kp N            &kp M    &kp COMMA      &kp DOT  &kp FSLH  &kp DEL
                            &kp LWIN  &kp LALT  &ht WinCode ESC  &th LSHFT SPACE    &th LCTRL RET  &lt WinNAV BSPC  &kp TAB  &kp LC(LSHFT)
             >;
         };
@@ -233,7 +233,7 @@
             bindings = <
 &trans  &kp F1    &kp F2        &kp F3     &kp F4     &kp F5                          &kp F6     &kp F7    &kp F8    &kp F9    &kp F10   &kp F11
 &trans  &kp EXCL  &kp AT        &kp HASH   &kp DLLR   &kp PRCNT                       &kp CARET  &kp AMPS  &kp STAR  &kp LPAR  &kp RPAR  &kp F12
-&trans  &t_crt    &win_ter_col  &kp GRAVE  &kp MINUS  &kp EQUAL                       &kp LBRC   &kp RBRC  &kp SQT   &kp DQT   &none     &kp LC(LG(D))
+&trans  &t_crt    &win_ter_col  &kp GRAVE  &kp MINUS  &kp EQUAL                       &kp LBRC   &kp RBRC  &kp SQT   &kp DQT   &none     &kp LC(TAB)
 &trans  &t_list   &win_ter_row  &kp TILDE  &kp PLUS   &kp UNDER  &to MAC    &to GAME  &kp LBKT   &kp RBKT  &kp PIPE  &kp BSLH  &kp DEL   &kp LC(LG(F4))
                                 &trans     &trans     &trans     &trans     &trans    &trans     &trans    &trans
             >;


### PR DESCRIPTION
- Modify key bindings in `lily58.keymap`
- Update key bindings for `LCTRL` and `LC(LG(D))`
- Adjust `F12` binding to a specific key function

Signed-off-by: HomePC <jackie@dast.tw>
