### PR TITLE
refactor: optimize keymap settings for Lily58, removing unnecessary macro line

### DIFF
--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -86,7 +86,6 @@
                 <&macro_release>,
                 <&kp LCTRL &kp LSHFT>,
                 <&macro_pause_for_release>,
-                <&macro_tap &kp W &kp S &kp L>,
                 <&macro_tap &kp RET>;
         };
 


### PR DESCRIPTION
- Remove the line with the macro_tap command for W S L in lily58.keymap

Signed-off-by: HomePC <jackie@dast.tw>
