### PR TITLE
重構：更改所有受影響文件中的鍵位映射序列為“GHOSTTY”

### DIFF
--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -76,7 +76,7 @@
                 <&kp LCMD>,
                 <&macro_pause_for_release>,
                 <&macro_tap>,
-                <&kp W &kp E &kp Z &kp T &kp E &kp R &kp M &kp RET>;
+                <&kp G &kp H &kp O &kp S &kp T &kp T &kp Y &kp RET>;
         };
 
         shot_win: screenshot_win {


### PR DESCRIPTION
- 將鍵位映射序列從 “WEZTERM” 更改為 “GHOSTTY”

Signed-off-by: HomePC-WSL <jackie@dast.tw>
