### PR TITLE
修正：更新鍵綁定和配置在按鍵映射文件中

### DIFF
--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -30,14 +30,6 @@
             bindings = <&kp>, <&kp>;
         };
 
-        em: esc_mod {
-            compatible = "zmk,behavior-hold-tap";
-            #binding-cells = <2>;
-            flavor = "hold-preferred";
-            tapping-term-ms = <400>;
-            bindings = <&mo>, <&kp>;
-        };
-
         bm: bspc_mod {
             compatible = "zmk,behavior-hold-tap";
             #binding-cells = <2>;
@@ -193,7 +185,7 @@
 &kp TAB    &kp Q   &kp W   &kp E     &kp R     &kp T                                              &kp Y            &kp U    &kp I          &kp O    &kp P     &kp LC(TAB)
 &kp LCTRL  &kp A   &kp S   &kp D     &kp F     &kp G                                              &kp H            &kp J    &kp K          &kp L    &kp SEMI  &kp LC(TAB)
 &kp LCTRL  &kp Z   &kp X   &kp C     &kp V     &kp B            &kp LS(LC(S))      &ter_wsl       &kp N            &kp M    &kp COMMA      &kp DOT  &kp FSLH  &kp DEL
-                           &kp LWIN  &kp LALT  &em WinCode ESC  &hm LSHFT SPACE    &hm LCTRL RET  &bm WinNAV BSPC  &kp TAB  &kp LC(LSHFT)
+                           &kp LWIN  &kp LALT  &lt WinCode ESC  &hm LSHFT SPACE    &hm LCTRL RET  &bm WinNAV BSPC  &kp TAB  &kp LC(LSHFT)
             >;
         };
 
@@ -229,7 +221,7 @@
 &kp TAB    &kp Q   &kp W   &kp E     &kp R     &kp T                                              &kp Y            &kp U    &kp I          &kp O    &kp P     &kp LC(TAB)
 &kp LCTRL  &kp A   &kp S   &kp D     &kp F     &kp G                                              &kp H            &kp J    &kp K          &kp L    &kp SEMI  &kp LC(TAB)
 &kp LCTRL  &kp Z   &kp X   &kp C     &kp V     &kp B            &spot              &ter_mac       &kp N            &kp M    &kp COMMA      &kp DOT  &kp FSLH  &kp DEL
-                           &kp LALT  &kp LCMD  &em MacCode ESC  &hm LSHFT SPACE    &hm LCTRL RET  &bm MacNav BSPC  &kp TAB  &kp LC(LSHFT)
+                           &kp LALT  &kp LCMD  &lt MacCode ESC  &hm LSHFT SPACE    &hm LCTRL RET  &bm MacNav BSPC  &kp TAB  &kp LC(LSHFT)
             >;
         };
 


### PR DESCRIPTION
- 從按鍵映射配置中移除 `esc_mod` 項目
- 更新按鍵綁定 `spot` 和 `ter_mac` 在按鍵映射配置中

Signed-off-by: Macbook <jackie@dast.tw>
