### PR TITLE
修復：重構鍵綁定和配置架構

### DIFF
--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -29,15 +29,6 @@
             quick-tap-ms = <150>;
             bindings = <&kp>, <&kp>;
         };
-
-        bm: bspc_mod {
-            compatible = "zmk,behavior-hold-tap";
-            #binding-cells = <2>;
-            flavor = "balanced";
-            tapping-term-ms = <200>;
-            quick-tap-ms = <150>;
-            bindings = <&mo>, <&kp>;
-        };
     };
 
     macros {
@@ -185,7 +176,7 @@
 &kp TAB    &kp Q   &kp W   &kp E     &kp R     &kp T                                              &kp Y            &kp U    &kp I          &kp O    &kp P     &kp LC(TAB)
 &kp LCTRL  &kp A   &kp S   &kp D     &kp F     &kp G                                              &kp H            &kp J    &kp K          &kp L    &kp SEMI  &kp LC(TAB)
 &kp LCTRL  &kp Z   &kp X   &kp C     &kp V     &kp B            &kp LS(LC(S))      &ter_wsl       &kp N            &kp M    &kp COMMA      &kp DOT  &kp FSLH  &kp DEL
-                           &kp LWIN  &kp LALT  &lt WinCode ESC  &hm LSHFT SPACE    &hm LCTRL RET  &bm WinNAV BSPC  &kp TAB  &kp LC(LSHFT)
+                           &kp LWIN  &kp LALT  &lt WinCode ESC  &hm LSHFT SPACE    &hm LCTRL RET  &lt WinNAV BSPC  &kp TAB  &kp LC(LSHFT)
             >;
         };
 
@@ -221,7 +212,7 @@
 &kp TAB    &kp Q   &kp W   &kp E     &kp R     &kp T                                              &kp Y            &kp U    &kp I          &kp O    &kp P     &kp LC(TAB)
 &kp LCTRL  &kp A   &kp S   &kp D     &kp F     &kp G                                              &kp H            &kp J    &kp K          &kp L    &kp SEMI  &kp LC(TAB)
 &kp LCTRL  &kp Z   &kp X   &kp C     &kp V     &kp B            &spot              &ter_mac       &kp N            &kp M    &kp COMMA      &kp DOT  &kp FSLH  &kp DEL
-                           &kp LALT  &kp LCMD  &lt MacCode ESC  &hm LSHFT SPACE    &hm LCTRL RET  &bm MacNav BSPC  &kp TAB  &kp LC(LSHFT)
+                           &kp LALT  &kp LCMD  &lt MacCode ESC  &hm LSHFT SPACE    &hm LCTRL RET  &lt MacNav BSPC  &kp TAB  &kp LC(LSHFT)
             >;
         };
 


### PR DESCRIPTION
- 刪除`bm：bspc_mod`部分
- 在鍵位圖中更新`LC`和`Win`鍵的鍵綁定

Signed-off-by: HomePC-WSL <jackie@dast.tw>
