### PR TITLE
功能：更新 ZMK Studio 配置和按键映射设置

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -15,5 +15,6 @@
 include:
   - board: nice_nano_v2
     shield: lily58_left nice_view_adapter nice_view
+    snippet: studio-rpc-usb-uart
   - board: nice_nano_v2
     shield: lily58_right nice_view_adapter nice_view

--- a/config/lily58.conf
+++ b/config/lily58.conf
@@ -6,7 +6,11 @@ CONFIG_BT_CTLR_TX_PWR_PLUS_8=y
 
 # Enable eager debouncing
 CONFIG_ZMK_KSCAN_DEBOUNCE_PRESS_MS=1
-CONFIG_ZMK_KSCAN_DEBOUNCE_RELEASE_MS=7
+CONFIG_ZMK_KSCAN_DEBOUNCE_RELEASE_MS=10
+
+# Enable ZMK Studio for Realtime Keymap Updates
+CONFIG_ZMK_STUDIO=y
+CONFIG_ZMK_STUDIO_LOCKING=n
 
 # Uncomment the following line to enable USB Logging (this increases power usage by a significant amount, turn it off when not in use)
 # CONFIG_ZMK_USB_LOGGING=y


### PR DESCRIPTION
- 将`studio-rpc-usb-uart`添加为`nice_nano_v2`板的代码片段
- 将`CONFIG_ZMK_KSCAN_DEBOUNCE_RELEASE_MS`从`7`增加到`10`
- 启用实时按键映射更新的`ZMK Studio`
- 禁用`ZMK Studio`的锁定

Signed-off-by: HomePC-WSL <jackie@dast.tw>
