### PR TITLE
重構: 為了一致性重構按鍵映射指令序列

### DIFF
--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -44,7 +44,7 @@
                 <&kp LWIN>,
                 <&macro_pause_for_release>,
                 <&macro_tap>,
-                <&kp W &kp E &kp Z &kp T &kp R &kp M &kp MINUS &kp G &kp U &kp I &kp RET>;
+                <&kp W &kp E &kp Z &kp T &kp E &kp R &kp M &kp MINUS &kp G &kp U &kp I &kp RET>;
         };
 
         ter_mac: terminal_macos {


### PR DESCRIPTION
- 將按鍵映射指令序列從 "WEZTRM" 更新為 "WEZTERM"

Signed-off-by: HomePC-WSL <jackie@dast.tw>
