### PR TITLE
修復：重構Lily58鍵盤的按鍵映射配置

### DIFF
--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -44,7 +44,7 @@
                 <&kp LWIN>,
                 <&macro_pause_for_release>,
                 <&macro_tap>,
-                <&kp W &kp E &kp Z &kp T &kp E &kp R &kp M &kp MINUS &kp G &kp U &kp I &kp RET>;
+                <&kp W &kp T &kp RET>;
         };
 
         ter_mac: terminal_macos {


### PR DESCRIPTION
- 編輯Lily58鍵盤的按鍵映射

Signed-off-by: OfficePC <jackie@dast.tw>
