### PR TITLE
功能: 重新設計 Lily58 鍵盤的鍵位映射

### DIFF
--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -175,7 +175,7 @@
 &kp ESC    &kp N1  &kp N2  &kp N3    &kp N4    &kp N5                                             &kp N6           &kp N7   &kp N8         &kp N9   &kp N0    &kp MINUS
 &kp TAB    &kp Q   &kp W   &kp E     &kp R     &kp T                                              &kp Y            &kp U    &kp I          &kp O    &kp P     &kp LC(TAB)
 &kp LCTRL  &kp A   &kp S   &kp D     &kp F     &kp G                                              &kp H            &kp J    &kp K          &kp L    &kp SEMI  &kp LC(TAB)
-&kp LCTRL  &kp Z   &kp X   &kp C     &kp V     &kp B            &kp LS(LC(S))      &ter_wsl       &kp N            &kp M    &kp COMMA      &kp DOT  &kp FSLH  &kp DEL
+&kp LCTRL  &kp Z   &kp X   &kp C     &kp V     &kp B            &kp LC(LS(N2))     &ter_wsl       &kp N            &kp M    &kp COMMA      &kp DOT  &kp FSLH  &kp DEL
                            &kp LWIN  &kp LALT  &lt WinCode ESC  &hm LSHFT SPACE    &hm LCTRL RET  &lt WinNAV BSPC  &kp TAB  &kp LC(LSHFT)
             >;
         };


### PR DESCRIPTION
- 更新 Lily58 鍵盤的鍵位映射配置
- 修改各種按鍵的鍵位映射，包括 LCTRL、Z、X、C、V、B、N、M、逗號、句點、斜線和刪除鍵
- 重新排列鍵位映射，將 LC(S) 改為 LS(N2)，調整部分按鍵組合

Signed-off-by: OfficePC <jackie@dast.tw>
