### PR TITLE
重構：為了命名一致性標準化按鍵映射條目

### DIFF
--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -32,7 +32,7 @@
             require-prior-idle-ms = <125>;
         };
 
-        em: esc_mod {
+        lm: layer_mod {
             compatible = "zmk,behavior-hold-tap";
             #binding-cells = <2>;
             flavor = "balanced";
@@ -207,7 +207,7 @@
 &kp TAB    &kp Q   &kp W   &kp E     &kp R     &kp T                                              &kp Y            &kp U    &kp I          &kp O    &kp P     &kp LC(TAB)
 &kp LCTRL  &kp A   &kp S   &kp D     &kp F     &kp G                                              &kp H            &kp J    &kp K          &kp L    &kp SEMI  &kp LC(TAB)
 &kp LCTRL  &kp Z   &kp X   &kp C     &kp V     &kp B            &kp LC(LS(N2))     &ter_wsl       &kp N            &kp M    &kp COMMA      &kp DOT  &kp FSLH  &kp DEL
-                           &kp LWIN  &kp LALT  &em WinCode ESC  &hm LSHFT SPACE    &hm LCTRL RET  &lt WinNAV BSPC  &kp TAB  &kp LC(LSHFT)
+                           &kp LWIN  &kp LALT  &lm WinCode ESC  &hm LSHFT SPACE    &hm LCTRL RET  &lm WinNAV BSPC  &kp TAB  &kp LC(LSHFT)
             >;
         };
 
@@ -243,7 +243,7 @@
 &kp TAB    &kp Q   &kp W   &kp E     &kp R     &kp T                                              &kp Y            &kp U    &kp I          &kp O    &kp P     &kp LC(TAB)
 &kp LCTRL  &kp A   &kp S   &kp D     &kp F     &kp G                                              &kp H            &kp J    &kp K          &kp L    &kp SEMI  &kp LC(TAB)
 &kp LCTRL  &kp Z   &kp X   &kp C     &kp V     &kp B            &spot              &ter_mac       &kp N            &kp M    &kp COMMA      &kp DOT  &kp FSLH  &kp DEL
-                           &kp LALT  &kp LCMD  &em MacCode ESC  &hm LSHFT SPACE    &hm LCTRL RET  &lt MacNav BSPC  &kp TAB  &kp LC(LSHFT)
+                           &kp LALT  &kp LCMD  &lm MacCode ESC  &hm LSHFT SPACE    &hm LCTRL RET  &lm MacNav BSPC  &kp TAB  &kp LC(LSHFT)
             >;
         };
 


### PR DESCRIPTION
- 將 `em: esc_mod` 重命名為 `lm: layer_mod`
- 更新 WinCode、WinNAV 和 MacCode 的按鍵映射條目，以符合新的命名方案

Signed-off-by: HomePC <jackie@dast.tw>
