### PR TITLE
功能：重塑引导加载程序处理器的按键映射绑定

### DIFF
--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -287,7 +287,7 @@
             bindings = <
 &none  &none  &none  &none  &none  &bt BT_CLR                        &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4  &none
 &none  &none  &none  &none  &none  &none                             &none         &none         &none         &none         &none         &none
-&none  &none  &none  &none  &none  &bootloader                       &bootloader   &to WIN       &to MAC       &none         &none         &none
+&none  &none  &none  &none  &none  &bootloader                       &bootloader   &to WinDef    &to MacDef    &none         &none         &none
 &none  &none  &none  &none  &none  &sys_reset   &none    &to WinDef  &sys_reset    &none         &none         &none         &none         &none
                      &none  &none  &none        &none    &none       &none         &none         &none
             >;


### PR DESCRIPTION
- 修改引导加载程序的按键映射绑定，使其默认为WinDef和MacDef

Signed-off-by: OfficePC <jackie@dast.tw>
