### PR TITLE
重構：調整輸入偏好和點擊靈敏度

### DIFF
--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -24,9 +24,9 @@
         hm: hold_mod {
             compatible = "zmk,behavior-hold-tap";
             #binding-cells = <2>;
-            flavor = "tap-preferred";
+            flavor = "hold-preferred";
             tapping-term-ms = <200>;
-            quick-tap-ms = <200>;
+            quick-tap-ms = <150>;
             bindings = <&kp>, <&kp>;
 
             require-prior-idle-ms = <125>;


### PR DESCRIPTION
- 將「flavor」從“tap-preferred”更改為“hold-preferred”
- 將「quick-tap-ms」從200減少到150

Signed-off-by: OfficePC <jackie@dast.tw>
