### PR TITLE
修正：重構終端機和視窗行為映射

### DIFF
--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -46,6 +46,8 @@
         ter_wsl: terminal_windows {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
+            wait-ms = <0>;
+            tap-ms = <0>;
             bindings =
                 <&macro_press>,
                 <&kp LWIN>,
@@ -61,6 +63,8 @@
         ter_mac: terminal_macos {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
+            wait-ms = <0>;
+            tap-ms = <0>;
             bindings =
                 <&macro_press>,
                 <&kp LCMD>,
@@ -76,6 +80,8 @@
         shot_win: screenshot_win {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
+            wait-ms = <0>;
+            tap-ms = <0>;
             bindings =
                 <&macro_press>,
                 <&kp LG(LSHFT)>,
@@ -88,6 +94,8 @@
         shot_mac: screenshot_mac {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
+            wait-ms = <0>;
+            tap-ms = <0>;
             bindings =
                 <&macro_press>,
                 <&kp LG(LC(LSHFT))>,
@@ -100,6 +108,8 @@
         max_win: windowmax_win {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
+            wait-ms = <0>;
+            tap-ms = <0>;
             bindings =
                 <&macro_press>,
                 <&kp LWIN>,
@@ -112,6 +122,8 @@
         min_win: windowmin_win {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
+            wait-ms = <0>;
+            tap-ms = <0>;
             bindings =
                 <&macro_press>,
                 <&kp LWIN>,
@@ -124,6 +136,8 @@
         max_mac: windowmax_mac {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
+            wait-ms = <0>;
+            tap-ms = <0>;
             bindings =
                 <&macro_press>,
                 <&kp GLOBE>,
@@ -136,6 +150,8 @@
         min_mac: windowmin_mac {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
+            wait-ms = <0>;
+            tap-ms = <0>;
             bindings =
                 <&macro_press>,
                 <&kp GLOBE &kp LCTRL>,
@@ -148,6 +164,8 @@
         spot: spotlight_mac {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
+            wait-ms = <0>;
+            tap-ms = <0>;
             bindings =
                 <&macro_press>,
                 <&kp LCMD>,
@@ -160,6 +178,8 @@
         rec_mac: screenrecord_mac {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
+            wait-ms = <0>;
+            tap-ms = <0>;
             bindings =
                 <&macro_press>,
                 <&kp LG(LSHFT)>,
@@ -172,24 +192,32 @@
         col: tmux_column {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
+            wait-ms = <0>;
+            tap-ms = <0>;
             bindings = <&macro_tap>, <&kp LC(A) &kp PIPE>;
         };
 
         row: tmux_row {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
+            wait-ms = <0>;
+            tap-ms = <0>;
             bindings = <&macro_tap>, <&kp LC(A) &kp MINUS>;
         };
 
         list: tmux_list {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
+            wait-ms = <0>;
+            tap-ms = <0>;
             bindings = <&macro_tap>, <&kp LC(A) &kp W>;
         };
 
         tabs: tmux_create {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
+            wait-ms = <0>;
+            tap-ms = <0>;
             bindings = <&macro_tap>, <&kp LC(A) &kp C>;
         };
     };


### PR DESCRIPTION
- 將`wait-ms = 0;`和`tap-ms = 0;`新增至不同終端機和視窗行為映射

Signed-off-by: HomePC <jackie@dast.tw>
