### PR TITLE
重構：統一並標準化跨作業系統的鍵綁定

### DIFF
--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -21,14 +21,13 @@
 
 / {
     behaviors {
-        hm: hold_mod {
+        rm: row_mod {
             compatible = "zmk,behavior-hold-tap";
             #binding-cells = <2>;
             flavor = "tap-preferred";
             tapping-term-ms = <200>;
             quick-tap-ms = <150>;
             bindings = <&kp>, <&kp>;
-
             require-prior-idle-ms = <125>;
         };
 
@@ -233,7 +232,7 @@
 &kp TAB    &kp Q   &kp W   &kp E     &kp R     &kp T                                              &kp Y            &kp U    &kp I          &kp O    &kp P     &kp LC(TAB)
 &kp LCTRL  &kp A   &kp S   &kp D     &kp F     &kp G                                              &kp H            &kp J    &kp K          &kp L    &kp SEMI  &kp LC(TAB)
 &kp LCTRL  &kp Z   &kp X   &kp C     &kp V     &kp B            &kp LC(LS(N2))     &ter_wsl       &kp N            &kp M    &kp COMMA      &kp DOT  &kp FSLH  &kp DEL
-                           &kp LWIN  &kp LALT  &lm WinCode ESC  &hm LSHFT SPACE    &hm LCTRL RET  &lm WinNav BSPC  &kp TAB  &kp LC(LSHFT)
+                           &kp LWIN  &kp LALT  &lm WinCode ESC  &rm LSHFT SPACE    &rm LCTRL RET  &lm WinNav BSPC  &kp TAB  &kp LC(LSHFT)
             >;
         };
 
@@ -269,7 +268,7 @@
 &kp TAB    &kp Q   &kp W   &kp E     &kp R     &kp T                                              &kp Y            &kp U    &kp I          &kp O    &kp P     &kp LC(TAB)
 &kp LCTRL  &kp A   &kp S   &kp D     &kp F     &kp G                                              &kp H            &kp J    &kp K          &kp L    &kp SEMI  &kp LC(TAB)
 &kp LCTRL  &kp Z   &kp X   &kp C     &kp V     &kp B            &spot              &ter_mac       &kp N            &kp M    &kp COMMA      &kp DOT  &kp FSLH  &kp DEL
-                           &kp LALT  &kp LCMD  &lm MacCode ESC  &hm LSHFT SPACE    &hm LCTRL RET  &lm MacNav BSPC  &kp TAB  &kp LC(LSHFT)
+                           &kp LALT  &kp LCMD  &lm MacCode ESC  &rm LSHFT SPACE    &rm LCTRL RET  &lm MacNav BSPC  &kp TAB  &kp LC(LSHFT)
             >;
         };
 


### PR DESCRIPTION
- 從 `hm: hold_mod` 更改為 `rm: row_mod`
- 更新特殊鍵（如 LWIN 和 LALT）的鍵綁定
- 調整不同作業系統（Windows 和 Mac）的鍵綁定
- 重新設計鍵綁定以提高可讀性和一致性

Signed-off-by: HomePC <jackie@dast.tw>
