### PR TITLE
修订：調整鍵盤映射中的時序設定以改善功能

### DIFF
--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -44,7 +44,7 @@
             compatible = "zmk,behavior-hold-tap";
             #binding-cells = <2>;
             flavor = "tap-unless-interrupted";
-            tapping-term-ms = <100>;
+            tapping-term-ms = <250>;
             quick-tap-ms = <200>;
             bindings = <&kp>, <&kp>;
             hold-trigger-key-positions = <25 26 27 28 31 32 33 34>;


### PR DESCRIPTION
- 在Lily58鍵盤映射中，將輕敲時限從100毫秒增加至250毫秒。

Signed-off-by: HomePC <jackie@dast.tw>
