### PR TITLE
重構：重新設定鍵盤映射中的按鍵綁定和行為

### DIFF
--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -43,11 +43,10 @@
         pht: positional_hold_tap {
             compatible = "zmk,behavior-hold-tap";
             #binding-cells = <2>;
-            flavor = "tap-unless-interrupted";
-            tapping-term-ms = <250>;
-            quick-tap-ms = <200>;
+            flavor = "balanced";
+            tapping-term-ms = <200>;
+            quick-tap-ms = <0>;
             bindings = <&kp>, <&kp>;
-            hold-trigger-key-positions = <25 26 27 28 31 32 33 34>;
         };
     };
 
@@ -240,7 +239,7 @@
             bindings = <
 &kp ESC    &kp N1        &kp N2       &kp N3       &kp N4        &kp N5                                             &kp N6           &kp N7        &kp N8        &kp N9       &kp N0           &kp MINUS
 &kp TAB    &kp Q         &kp W        &kp E        &kp R         &kp T                                              &kp Y            &kp U         &kp I         &kp O        &kp P            &kp LC(TAB)
-&kp LCTRL  &pht LSHFT A  &pht LGUI S  &pht LALT D  &pht LCTRL F  &kp G                                              &kp H            &pht LCTRL J  &pht LALT K   &pht LGUI L  &pht LSHFT SEMI  &kp LC(TAB)
+&kp LCTRL  &pht LCTRL A  &pht LGUI S  &pht LALT D  &pht LSHFT F  &kp G                                              &kp H            &pht LSHFT J  &pht LALT K   &pht LGUI L  &pht LCTRL SEMI  &kp LC(TAB)
 &kp LCTRL  &kp Z         &kp X        &kp C        &kp V         &kp B            &kp LC(LS(N2))     &ter_wsl       &kp N            &kp M         &kp COMMA     &kp DOT      &kp FSLH         &kp DEL
                                       &kp LWIN     &kp LALT      &lm WinCode ESC  &rm LSHFT SPACE    &rm LCTRL RET  &lm WinNav BSPC  &kp TAB       &kp LC(LSHFT)
             >;


### PR DESCRIPTION
- 更新鍵盤映射中的行為保持點擊設定
- 修改控制、Shift和其他按鍵的鍵綁定
- 重構鍵盤映射以使用具有不同定時配置的平衡風格

Signed-off-by: HomePC-WSL <jackie@dast.tw>
