### PR TITLE
重構：重新設計鍵映射並移除過時行為

### DIFF
--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -39,15 +39,6 @@
             quick-tap-ms = <200>;
             bindings = <&mo>, <&kp>;
         };
-
-        pht: positional_hold_tap {
-            compatible = "zmk,behavior-hold-tap";
-            #binding-cells = <2>;
-            flavor = "balanced";
-            tapping-term-ms = <200>;
-            quick-tap-ms = <0>;
-            bindings = <&kp>, <&kp>;
-        };
     };
 
     macros {
@@ -237,11 +228,11 @@
             label = "WinDef";
             display-name = "Windows";
             bindings = <
-&kp ESC    &kp N1        &kp N2       &kp N3       &kp N4        &kp N5                                             &kp N6           &kp N7        &kp N8        &kp N9       &kp N0           &kp MINUS
-&kp TAB    &kp Q         &kp W        &kp E        &kp R         &kp T                                              &kp Y            &kp U         &kp I         &kp O        &kp P            &kp LC(TAB)
-&kp LCTRL  &pht LCTRL A  &pht LGUI S  &pht LALT D  &pht LSHFT F  &kp G                                              &kp H            &pht LSHFT J  &pht LALT K   &pht LGUI L  &pht LCTRL SEMI  &kp LC(TAB)
-&kp LCTRL  &kp Z         &kp X        &kp C        &kp V         &kp B            &kp LC(LS(N2))     &ter_wsl       &kp N            &kp M         &kp COMMA     &kp DOT      &kp FSLH         &kp DEL
-                                      &kp LWIN     &kp LALT      &lm WinCode ESC  &rm LSHFT SPACE    &rm LCTRL RET  &lm WinNav BSPC  &kp TAB       &kp LC(LSHFT)
+&kp ESC    &kp N1  &kp N2  &kp N3    &kp N4    &kp N5                                             &kp N6           &kp N7   &kp N8         &kp N9   &kp N0    &kp MINUS
+&kp TAB    &kp Q   &kp W   &kp E     &kp R     &kp T                                              &kp Y            &kp U    &kp I          &kp O    &kp P     &kp LC(TAB)
+&kp LCTRL  &kp A   &kp S   &kp D     &kp F     &kp G                                              &kp H            &kp J    &kp K          &kp L    &kp SEMI  &kp LC(TAB)
+&kp LCTRL  &kp Z   &kp X   &kp C     &kp V     &kp B            &kp LC(LS(N2))     &ter_wsl       &kp N            &kp M    &kp COMMA      &kp DOT  &kp FSLH  &kp DEL
+                           &kp LWIN  &kp LALT  &lm WinCode ESC  &rm LSHFT SPACE    &rm LCTRL RET  &lm WinNav BSPC  &kp TAB  &kp LC(LSHFT)
             >;
         };
 


### PR DESCRIPTION
- 刪除與 `positional_hold_tap` 行為相關的程式區塊
- 更新 `lily58.keymap` 配置中的鍵綁定，以修正修改鍵的分配

Signed-off-by: HomePC-WSL <jackie@dast.tw>
