### PR TITLE
建立: 更新Lily58鍵盤映射以使用 `quick-tap-ms` 值為 `0`

### DIFF
--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -36,7 +36,7 @@
             #binding-cells = <2>;
             flavor = "balanced";
             tapping-term-ms = <200>;
-            quick-tap-ms = <200>;
+            quick-tap-ms = <0>;
             bindings = <&mo>, <&kp>;
         };
     };


### PR DESCRIPTION
- 在Lily58鍵盤映射中將`quick-tap-ms`值更新為`0`。

Signed-off-by: HomePC-WSL <jackie@dast.tw>
