### PR TITLE
功能：重構 Lily58 鍵盤配置和按鍵映射

### DIFF
--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -204,11 +204,11 @@
             label = "MacNav";
             display-name = "MacNAV";
             bindings = <
-&trans  &kp F1         &kp F2         &kp F3    &kp F4    &kp F5                             &kp F6        &kp F7        &kp F8      &kp F9      &kp F10             &kp F11
-&trans  &kp N1         &kp N2         &kp N3    &kp N4    &kp N5                             &kp N6        &kp N7        &kp N8      &kp N9      &kp N0              &kp F12
-&trans  &kp LG(LS(4))  &kp CAPS       &max_mac  &kp HOME  &kp PG_UP                          &kp LEFT      &kp DOWN      &kp UP      &kp RIGHT   &kp LC(LEFT)        &kp LC(RIGHT)
-&trans  &ter_mac       &kp LG(SPACE)  &min_mac  &kp END   &kp PG_DN  &to Game    &to WinDef  &kp C_VOL_DN  &kp C_VOL_UP  &kp C_PREV  &kp C_NEXT  &kp LG(LC(LS(N5)))  &none
-                                      &trans    &trans    &trans     &trans      &trans      &trans        &trans        &trans
+&trans  &kp F1          &kp F2         &kp F3    &kp F4    &kp F5                             &kp F6        &kp F7        &kp F8      &kp F9      &kp F10             &kp F11
+&trans  &kp N1          &kp N2         &kp N3    &kp N4    &kp N5                             &kp N6        &kp N7        &kp N8      &kp N9      &kp N0              &kp F12
+&trans  &kp LG(LS(N4))  &kp CAPS       &max_mac  &kp HOME  &kp PG_UP                          &kp LEFT      &kp DOWN      &kp UP      &kp RIGHT   &kp LC(LEFT)        &kp LC(RIGHT)
+&trans  &ter_mac        &kp LG(SPACE)  &min_mac  &kp END   &kp PG_DN  &to Game    &to WinDef  &kp C_VOL_DN  &kp C_VOL_UP  &kp C_PREV  &kp C_NEXT  &kp LG(LC(LS(N5)))  &none
+                                       &trans    &trans    &trans     &trans      &trans      &trans        &trans        &trans
             >;
         };
 


### PR DESCRIPTION
- 更新 Lily58 鍵盤的按鍵映射
- 更改分配給鍵盤 LG(LS(N4)) 的功能
- 進行調整，以提高鍵盤配置的功能性

Signed-off-by: Macbook <jackie@dast.tw>
