### PR TITLE
重構: 重構鍵盤映射、系統重置和引導程序設置

### DIFF
--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -228,11 +228,11 @@
             label = "SYS";
             display-name = "System";
             bindings = <
-&none  &none  &none  &none  &none  &bt BT_CLR                        &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4  &none
-&none  &none  &none  &none  &none  &none                             &none         &none         &none         &none         &none         &none
-&none  &none  &none  &none  &none  &bootloader                       &bootloader   &to WinDef    &to MacDef    &none         &none         &none
-&none  &none  &none  &none  &none  &sys_reset   &none    &to WinDef  &sys_reset    &none         &none         &none         &none         &none
-                     &none  &none  &none        &none    &to MacDef  &none         &none         &none
+&none  &none  &none  &none  &none  &bt BT_CLR                   &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4  &none
+&none  &none  &none  &none  &none  &none                        &none         &none         &none         &none         &none         &none
+&none  &none  &none  &none  &none  &bootloader                  &bootloader   &to WinDef    &to MacDef    &none         &none         &none
+&none  &none  &none  &none  &none  &sys_reset   &none    &none  &sys_reset    &none         &none         &none         &none         &none
+                     &none  &none  &none        &none    &none  &none         &none         &none
             >;
         };
     };


### PR DESCRIPTION
- 更新鍵盤映射配置
- 刪除與系統重置無關的不必要行
- 為了清晰度，重構引導程序設置

Signed-off-by: HomePC-WSL <jackie@dast.tw>
