### PR TITLE
功能：重構 Lily58 配置檔中的按鍵映射

### DIFF
--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -97,7 +97,7 @@
                 <&kp LWIN>,
                 <&macro_pause_for_release>,
                 <&macro_tap>,
-                <&kp M &kp S &kp E &kp D &kp G &kp E>;
+                <&kp M &kp S &kp E &kp D &kp G &kp E &kp RET>;
         };
 
         col: tmux_column {


### PR DESCRIPTION
- 在 Lily58 配置檔中添加了對 "RET" 按鍵的映射。

Signed-off-by: HomePC-WSL <jackie@dast.tw>
