### PR TITLE
重新設計鍵盤映射，以分層上下文觸發方向鍵

### DIFF
--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -140,11 +140,11 @@
             label = "WinDef";
             display-name = "Windows";
             bindings = <
-&kp ESC    &kp N1  &kp N2  &kp N3    &kp N4    &kp N5                                             &kp N6           &kp N7        &kp N8      &kp N9   &kp N0    &kp MINUS
-&kp TAB    &kp Q   &kp W   &kp E     &kp R     &kp T                                              &kp Y            &kp U         &kp I       &kp O    &kp P     &kp LC(TAB)
-&kp LCTRL  &kp A   &kp S   &kp D     &kp F     &kp G                                              &kp H            &kp J         &kp K       &kp L    &kp SEMI  &kp C_PP
-&kp LCTRL  &kp Z   &kp X   &kp C     &kp V     &kp B            &kp LC(LS(N2))     &ter_wsl       &kp N            &kp M         &kp COMMA   &kp DOT  &kp FSLH  &kp DEL
-                           &kp LWIN  &kp LALT  &lt WinCode ESC  &mt LSHFT SPACE    &mt LCTRL RET  &lt WinNav BSPC  &kp LS(DOWN)  &kp LS(UP)
+&kp ESC    &kp N1  &kp N2  &kp N3    &kp N4    &kp N5                                             &kp N6           &kp N7            &kp N8          &kp N9   &kp N0    &kp MINUS
+&kp TAB    &kp Q   &kp W   &kp E     &kp R     &kp T                                              &kp Y            &kp U             &kp I           &kp O    &kp P     &kp LC(TAB)
+&kp LCTRL  &kp A   &kp S   &kp D     &kp F     &kp G                                              &kp H            &kp J             &kp K           &kp L    &kp SEMI  &kp C_PP
+&kp LCTRL  &kp Z   &kp X   &kp C     &kp V     &kp B            &kp LC(LS(N2))     &ter_wsl       &kp N            &kp M             &kp COMMA       &kp DOT  &kp FSLH  &kp DEL
+                           &kp LWIN  &kp LALT  &lt WinCode ESC  &mt LSHFT SPACE    &mt LCTRL RET  &lt WinNav BSPC  &kp LC(LS(DOWN))  &kp LC(LS(UP))
             >;
         };
 


### PR DESCRIPTION
feat: 重新設計鍵盤映射，以分層上下文觸發方向鍵

- 更新鍵盤映射，將向下和向上方向鍵的觸發改為使用分層上下文。
- 保持現有的鍵位分配及其功能。

Signed-off-by: HomePC-WSL <jackie@dast.tw>
