### PR TITLE
重構 WinCode 和 MacCode 的瞬時修飾符處理

### DIFF
--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -140,11 +140,11 @@
             label = "WinDef";
             display-name = "Windows";
             bindings = <
-&kp ESC    &kp N1  &kp N2  &kp N3    &kp N4    &kp N5                                             &kp N6           &kp N7            &kp N8          &kp N9   &kp N0    &kp MINUS
-&kp TAB    &kp Q   &kp W   &kp E     &kp R     &kp T                                              &kp Y            &kp U             &kp I           &kp O    &kp P     &kp LC(TAB)
-&kp LCTRL  &kp A   &kp S   &kp D     &kp F     &kp G                                              &kp H            &kp J             &kp K           &kp L    &kp SEMI  &kp C_PP
-&kp LCTRL  &kp Z   &kp X   &kp C     &kp V     &kp B            &kp LC(LS(N2))     &ter_wsl       &kp N            &kp M             &kp COMMA       &kp DOT  &kp FSLH  &kp DEL
-                           &kp LWIN  &kp LALT  &lt WinCode ESC  &mt LSHFT SPACE    &mt LCTRL RET  &lt WinNav BSPC  &kp LC(LS(DOWN))  &kp LC(LS(UP))
+&kp ESC    &kp N1  &kp N2  &kp N3    &kp N4    &kp N5                                         &kp N6           &kp N7            &kp N8          &kp N9   &kp N0    &kp MINUS
+&kp TAB    &kp Q   &kp W   &kp E     &kp R     &kp T                                          &kp Y            &kp U             &kp I           &kp O    &kp P     &kp LC(TAB)
+&kp LCTRL  &kp A   &kp S   &kp D     &kp F     &kp G                                          &kp H            &kp J             &kp K           &kp L    &kp SEMI  &kp C_PP
+&kp LCTRL  &kp Z   &kp X   &kp C     &kp V     &kp B        &kp LC(LS(N2))     &ter_wsl       &kp N            &kp M             &kp COMMA       &kp DOT  &kp FSLH  &kp DEL
+                           &kp LWIN  &kp LALT  &mo WinCode  &mt LSHFT SPACE    &mt LCTRL RET  &lt WinNav BSPC  &kp LC(LS(DOWN))  &kp LC(LS(UP))
             >;
         };
 
@@ -176,11 +176,11 @@
             label = "MacDef";
             display-name = "MacOS";
             bindings = <
-&kp ESC    &kp N1  &kp N2  &kp N3    &kp N4    &kp N5                                             &kp N6           &kp N7   &kp N8         &kp N9   &kp N0    &kp MINUS
-&kp TAB    &kp Q   &kp W   &kp E     &kp R     &kp T                                              &kp Y            &kp U    &kp I          &kp O    &kp P     &kp LC(TAB)
-&kp LCTRL  &kp A   &kp S   &kp D     &kp F     &kp G                                              &kp H            &kp J    &kp K          &kp L    &kp SEMI  &kp C_PP
-&kp LCTRL  &kp Z   &kp X   &kp C     &kp V     &kp B            &kp LG(SPACE)      &ter_mac       &kp N            &kp M    &kp COMMA      &kp DOT  &kp FSLH  &kp DEL
-                           &kp LALT  &kp LCMD  &lt MacCode ESC  &mt LSHFT SPACE    &mt LCTRL RET  &lt MacNav BSPC  &kp TAB  &kp LC(LSHFT)
+&kp ESC    &kp N1  &kp N2  &kp N3    &kp N4    &kp N5                                         &kp N6           &kp N7   &kp N8         &kp N9   &kp N0    &kp MINUS
+&kp TAB    &kp Q   &kp W   &kp E     &kp R     &kp T                                          &kp Y            &kp U    &kp I          &kp O    &kp P     &kp LC(TAB)
+&kp LCTRL  &kp A   &kp S   &kp D     &kp F     &kp G                                          &kp H            &kp J    &kp K          &kp L    &kp SEMI  &kp C_PP
+&kp LCTRL  &kp Z   &kp X   &kp C     &kp V     &kp B        &kp LG(SPACE)      &ter_mac       &kp N            &kp M    &kp COMMA      &kp DOT  &kp FSLH  &kp DEL
+                           &kp LALT  &kp LCMD  &mo MacCode  &mt LSHFT SPACE    &mt LCTRL RET  &lt MacNav BSPC  &kp TAB  &kp LC(LSHFT)
             >;
         };
 


### PR DESCRIPTION
重構：重構 WinCode 和 MacCode 的瞬時修飾符處理

- 將 WinCode 的處理改為瞬時修飾符
- 更新 MacCode 的處理為瞬時修飾符
- 改善排版以提升可讀性，並不改變功能

Signed-off-by: OfficePC-WSL <jackie@dast.tw>
