### PR TITLE
重構 Windows 和 Mac 的按鍵映射配置

### DIFF
--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -140,11 +140,11 @@
             label = "WinDef";
             display-name = "Windows";
             bindings = <
-&kp ESC    &kp N1  &kp N2  &kp N3    &kp N4    &kp N5                                             &kp N6           &kp N7            &kp N8          &kp N9   &kp N0    &kp MINUS
-&kp TAB    &kp Q   &kp W   &kp E     &kp R     &kp T                                              &kp Y            &kp U             &kp I           &kp O    &kp P     &kp LC(TAB)
-&kp LCTRL  &kp A   &kp S   &kp D     &kp F     &kp G                                              &kp H            &kp J             &kp K           &kp L    &kp SEMI  &kp C_PP
-&kp LCTRL  &kp Z   &kp X   &kp C     &kp V     &kp B            &kp LC(LS(N2))     &ter_wsl       &kp N            &kp M             &kp COMMA       &kp DOT  &kp FSLH  &kp DEL
-                           &kp LWIN  &kp LALT  &lt WinCode ESC  &mt LSHFT SPACE    &mt LCTRL RET  &lt WinNav BSPC  &kp LC(LS(DOWN))  &kp LC(LS(UP))
+&kp ESC    &kp N1  &kp N2  &kp N3    &kp N4        &kp N5                                         &kp N6           &kp N7            &kp N8          &kp N9   &kp N0    &kp MINUS
+&kp TAB    &kp Q   &kp W   &kp E     &kp R         &kp T                                          &kp Y            &kp U             &kp I           &kp O    &kp P     &kp LC(TAB)
+&kp LCTRL  &kp A   &kp S   &kp D     &kp F         &kp G                                          &kp H            &kp J             &kp K           &kp L    &kp SEMI  &kp C_PP
+&kp LCTRL  &kp Z   &kp X   &kp C     &kp V         &kp B        &kp LC(LS(N2))     &ter_wsl       &kp N            &kp M             &kp COMMA       &kp DOT  &kp FSLH  &kp DEL
+                           &kp LWIN  &mt LALT ESC  &mo WinCode  &mt LSHFT SPACE    &mt LCTRL RET  &lt WinNav BSPC  &kp LC(LS(DOWN))  &kp LC(LS(UP))
             >;
         };
 
@@ -176,11 +176,11 @@
             label = "MacDef";
             display-name = "MacOS";
             bindings = <
-&kp ESC    &kp N1  &kp N2  &kp N3    &kp N4    &kp N5                                             &kp N6           &kp N7   &kp N8         &kp N9   &kp N0    &kp MINUS
-&kp TAB    &kp Q   &kp W   &kp E     &kp R     &kp T                                              &kp Y            &kp U    &kp I          &kp O    &kp P     &kp LC(TAB)
-&kp LCTRL  &kp A   &kp S   &kp D     &kp F     &kp G                                              &kp H            &kp J    &kp K          &kp L    &kp SEMI  &kp C_PP
-&kp LCTRL  &kp Z   &kp X   &kp C     &kp V     &kp B            &kp LG(SPACE)      &ter_mac       &kp N            &kp M    &kp COMMA      &kp DOT  &kp FSLH  &kp DEL
-                           &kp LALT  &kp LCMD  &lt MacCode ESC  &mt LSHFT SPACE    &mt LCTRL RET  &lt MacNav BSPC  &kp TAB  &kp LC(LSHFT)
+&kp ESC    &kp N1  &kp N2  &kp N3    &kp N4        &kp N5                                         &kp N6           &kp N7   &kp N8         &kp N9   &kp N0    &kp MINUS
+&kp TAB    &kp Q   &kp W   &kp E     &kp R         &kp T                                          &kp Y            &kp U    &kp I          &kp O    &kp P     &kp LC(TAB)
+&kp LCTRL  &kp A   &kp S   &kp D     &kp F         &kp G                                          &kp H            &kp J    &kp K          &kp L    &kp SEMI  &kp C_PP
+&kp LCTRL  &kp Z   &kp X   &kp C     &kp V         &kp B        &kp LG(SPACE)      &ter_mac       &kp N            &kp M    &kp COMMA      &kp DOT  &kp FSLH  &kp DEL
+                           &kp LALT  &mt LCMD ESC  &mo MacCode  &mt LSHFT SPACE    &mt LCTRL RET  &lt MacNav BSPC  &kp TAB  &kp LC(LSHFT)
             >;
         };
 


### PR DESCRIPTION
重構：重構 Windows 和 Mac 的按鍵映射配置

- 修改 Windows 和 Mac 配置的按鍵映射
- 更改 Windows 中左 Alt 鍵的相關操作
- 更新 Mac 中左控制鍵和 Esc 鍵的行為
- 調整按鍵映射定義的語法以提高清晰度

Signed-off-by: HomePC-WIN <jackie@dast.tw>
