### PR TITLE
docs: 新增 Lily58 ZMK 專案完整的貢獻指南

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,61 @@
+# Repository Guidelines
+
+本文件為此 ZMK 設定庫（Lily58 無線）之貢獻指南，協助你快速熟悉結構、建置與提交流程。
+
+## 專案結構與模組組織
+
+- `config/`: 主要設定（`lily58.keymap`、`lily58.conf`、`west.yml`）。
+- `IMG/`: 鍵盤/佈局相關圖片資產。
+- `.github/workflows/`: CI 建置流程。
+- `build.yaml`: CI 建置矩陣（左右半部與顯示模組）。
+
+## 建置、測試與開發指令
+
+首次建置（會抓取 ZMK 專案並建立工作區）：
+
+```bash
+west init -l config
+west update
+```
+
+本機分別建置左右半部（輸出位於 `build/<side>/zephyr/zmk.uf2`）：
+
+```bash
+west build -d build/left  -b nice_nano_v2 -- -DSHIELD=lily58_left
+west build -d build/right -b nice_nano_v2 -- -DSHIELD=lily58_right
+```
+
+常用：乾淨重建 `-p`、只換目標 `-t`：
+
+```bash
+west build -p=auto -d build/left  -b nice_nano_v2 -- -DSHIELD=lily58_left
+west build -p=auto -d build/right -b nice_nano_v2 -- -DSHIELD=lily58_right
+```
+
+## 程式風格與命名規範
+
+- 縮排：YAML 2 空白；`.keymap`/`.conf` 以 2 空白對齊區塊。
+- 檔名：鍵盤/板定義使用小寫與中線或底線（例：`lily58.keymap`）。
+- 層名稱：使用全大寫（例：`BASE`、`NAV`、`GAME`）。
+- 設定鍵（`.conf`）使用既有 `CONFIG_` 開關，不自創前綴。
+
+## 測試指引
+
+- 必須保證左右半部皆可成功建置且產生 `zmk.uf2`。
+- 重大變更請附上新舊層級對照（可放在 `IMG/`）或片段 keymap 差異。
+- 提交前確保 CI 綠燈；本機請先跑兩側建置以復現。
+
+## Commit 與 Pull Request 規範
+
+- 建議採用 Conventional Commits（本庫歷史含有 `ci:`、`build:`、`refactor:`）。
+  - 範例：`ci: 調整 Actions 觸發條件`、`build: 新增 nice_view 設定`。
+- PR 需包含：
+  - 變更摘要與動機、影響層級（列出新增/調整之層）。
+  - 關聯 issue（如有）、截圖或對應 `IMG/` 圖片。
+  - 本機建置結果（左右半部）與重現指令。
+
+## 安全與設定提示
+
+- 請勿提交產物與私密資料（`build/`、`.uf2`、序號/金鑰）。
+- 變更 `west.yml` 或 `build.yaml` 前，確認 CI 矩陣仍涵蓋左右半部與顯示模組。
+


### PR DESCRIPTION
- 為 Lily58 無線 ZMK 倉庫新增一份完整的中文貢獻指南文件。
- 記錄專案結構、建置與測試指令、程式碼風格及命名規範。
- 提供左右鍵盤半部清潔建置與重建的操作說明。
- 包含測試要求以及依照 Conventional Commits 規範的提交與拉取請求標準建議。
- 提醒安全作法，如避免提交建置產物與私密金鑰。

Signed-off-by: WSL <jackie@dast.tw>
