### PR TITLE
ci: 將 GitHub Actions 工作流程固定至特定版本標籤

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,4 +6,4 @@ on:
       - test
 jobs:
   build:
-    uses: zmkfirmware/zmk/.github/workflows/build-user-config.yml@main
+    uses: zmkfirmware/zmk/.github/workflows/build-user-config.yml@0.3


### PR DESCRIPTION
- 將 GitHub Actions 工作流程固定至特定版本 0.3，而非使用 main 分支

Signed-off-by: WSL <jackie@dast.tw>
