### PR TITLE
feat: 新增 YAML 鍵盤映射生成及 SVG 視覺化工具

### DIFF
--- a/IMG/lily58.svg
+++ b/IMG/lily58.svg
@@ -123,18 +123,7 @@ path.combo {
     visibility: hidden;
 }
 /* End Tabler Icons Cleanup */
-
-@media (prefers-color-scheme: dark) {
-svg.keymap { fill: #d1d6db; }
-rect.key { fill: #3f4750; }
-rect.key, rect.combo { stroke: #60666c; }
-rect.combo, rect.combo-separate { fill: #1f3d7a; }
-rect.held, rect.combo.held { fill: #854747; }
-text.label, text.footer { stroke: black; }
-text.trans { fill: #7e8184; }
-path.combo { stroke: #7f7f7f; }
-
-}</style>
+</style>
 <g transform="translate(30, 0)" class="layer-Windows">
 <text x="0" y="28" class="label" id="Windows">Windows:</text>
 <g transform="translate(0, 56)">
@@ -2054,5 +2043,4 @@ path.combo { stroke: #7f7f7f; }
 </g>
 </g>
 </g>
-<text x="954.0" y="3007.0" class="footer">Created with <a href="https://github.com/caksoylar/keymap-drawer">keymap-drawer</a></text></svg>
-
+</svg>

--- a/drawer.py
+++ b/drawer.py
@@ -1,0 +1,23 @@
+import subprocess
+from pathlib import Path
+
+
+def main():
+    base_dir = Path(".")
+    yaml_file = base_dir / "lily58_keymap.yaml"
+    svg_file = base_dir / "IMG/lily58.svg"
+    svg_file.parent.mkdir(parents=True, exist_ok=True)
+
+    subprocess.run(
+        "keymap parse -c 10 -z ./config/lily58.keymap > lily58_keymap.yaml",
+        shell=True,
+        check=True,
+    )
+    subprocess.run(
+        "keymap draw lily58_keymap.yaml > IMG/lily58.svg", shell=True, check=True
+    )
+    print(f"✅ 已生成 SVG: {svg_file}")
+
+
+if __name__ == "__main__":
+    main()

--- a/lily58_keymap.yaml
+++ b/lily58_keymap.yaml
@@ -1,0 +1,341 @@
+layout: {zmk_keyboard: lily58}
+layers:
+  Windows:
+  - [ESC, '1', '2', '3', '4', '5', '6', '7', '8', '9']
+  - ['0', '-', TAB, Q, W, E, R, T, Y, U]
+  - [I, O, P, Ctl+TAB, LCTRL, A, S, D, F, G]
+  - [H, J, K, L, ;, PP, LCTRL, Z, X, C]
+  - [V, B, Ctl+Sft+2, '&ter_wsl', N, M, ',', ., /, DEL]
+  - - LWIN
+    - {t: ESC, h: LALT}
+    - WinCode
+    - {t: SPACE, h: LSHFT}
+    - {t: RET, h: LCTRL}
+    - {t: BSPC, h: WinNAV}
+    - Ctl+Sft+DOWN
+    - Ctl+Sft+UP
+  WinCode:
+  - - {t: ▽, type: trans}
+    - F1
+    - F2
+    - F3
+    - F4
+    - F5
+    - F6
+    - F7
+    - F8
+    - F9
+  - - F10
+    - F11
+    - {t: ▽, type: trans}
+    - '!'
+    - '@'
+    - '#'
+    - $
+    - '%'
+    - ^
+    - '&'
+  - - '*'
+    - (
+    - )
+    - F12
+    - {t: ▽, type: trans}
+    - '&list'
+    - '&col'
+    - '`'
+    - '-'
+    - '='
+  - - '{'
+    - '}'
+    - ''''
+    - '"'
+    - Alt+F4
+    - Ctl+Gui+D
+    - {t: ▽, type: trans}
+    - '&tabs'
+    - '&row'
+    - '~'
+  - - +
+    - _
+    - {t: MacOS, h: toggle}
+    - {t: Game, h: toggle}
+    - '['
+    - ']'
+    - '|'
+    - \
+    - DEL
+    - Ctl+Gui+F4
+  - - {t: ▽, type: trans}
+    - {t: ▽, type: trans}
+    - {type: held}
+    - {t: ▽, type: trans}
+    - {t: ▽, type: trans}
+    - {t: ▽, type: trans}
+    - {t: ▽, type: trans}
+    - {t: ▽, type: trans}
+  WinNAV:
+  - - {t: ▽, type: trans}
+    - F1
+    - F2
+    - F3
+    - F4
+    - F5
+    - F6
+    - F7
+    - F8
+    - F9
+  - - F10
+    - F11
+    - {t: ▽, type: trans}
+    - '1'
+    - '2'
+    - '3'
+    - '4'
+    - '5'
+    - '6'
+    - '7'
+  - - '8'
+    - '9'
+    - '0'
+    - F12
+    - {t: ▽, type: trans}
+    - Gui+Sft+S
+    - CAPS
+    - Gui+UP
+    - HOME
+    - PG UP
+  - - LEFT
+    - DOWN
+    - UP
+    - RIGHT
+    - Ctl+Gui+LEFT
+    - Ctl+Gui+RIGHT
+    - {t: ▽, type: trans}
+    - '&ter_wsl'
+    - '&edge'
+    - Gui+DOWN
+  - - END
+    - PG DN
+    - {t: MacOS, h: toggle}
+    - {t: Game, h: toggle}
+    - VOL DN
+    - VOL UP
+    - PREV
+    - NEXT
+    - Ctl+Alt+DEL
+    - DEL
+  - - {t: ▽, type: trans}
+    - {t: ▽, type: trans}
+    - {t: ▽, type: trans}
+    - {t: ▽, type: trans}
+    - {t: ▽, type: trans}
+    - {type: held}
+    - {t: ▽, type: trans}
+    - {t: ▽, type: trans}
+  MacOS:
+  - [ESC, '1', '2', '3', '4', '5', '6', '7', '8', '9']
+  - ['0', '-', TAB, Q, W, E, R, T, Y, U]
+  - [I, O, P, Ctl+TAB, LCTRL, A, S, D, F, G]
+  - [H, J, K, L, ;, PP, LCTRL, Z, X, C]
+  - [V, B, Gui+SPACE, '&ter_mac', N, M, ',', ., /, DEL]
+  - - LALT
+    - {t: ESC, h: LCMD}
+    - MacCode
+    - {t: SPACE, h: LSHFT}
+    - {t: RET, h: LCTRL}
+    - {t: BSPC, h: MacNAV}
+    - TAB
+    - Ctl+LSHFT
+  MacCode:
+  - - {t: ▽, type: trans}
+    - F1
+    - F2
+    - F3
+    - F4
+    - F5
+    - F6
+    - F7
+    - F8
+    - F9
+  - - F10
+    - F11
+    - {t: ▽, type: trans}
+    - '!'
+    - '@'
+    - '#'
+    - $
+    - '%'
+    - ^
+    - '&'
+  - - '*'
+    - (
+    - )
+    - F12
+    - {t: ▽, type: trans}
+    - '&list'
+    - '&col'
+    - '`'
+    - '-'
+    - '='
+  - - '{'
+    - '}'
+    - ''''
+    - '"'
+    - Ctl+TAB
+    - Gui+Ctl+F
+    - {t: ▽, type: trans}
+    - '&tabs'
+    - '&row'
+    - '~'
+  - - +
+    - _
+    - {t: Windows, h: toggle}
+    - {t: Game, h: toggle}
+    - '['
+    - ']'
+    - '|'
+    - \
+    - DEL
+    - Gui+RET
+  - - {t: ▽, type: trans}
+    - {t: ▽, type: trans}
+    - {type: held}
+    - {t: ▽, type: trans}
+    - {t: ▽, type: trans}
+    - {t: ▽, type: trans}
+    - {t: ▽, type: trans}
+    - {t: ▽, type: trans}
+  MacNAV:
+  - - {t: ▽, type: trans}
+    - F1
+    - F2
+    - F3
+    - F4
+    - F5
+    - F6
+    - F7
+    - F8
+    - F9
+  - - F10
+    - F11
+    - {t: ▽, type: trans}
+    - '1'
+    - '2'
+    - '3'
+    - '4'
+    - '5'
+    - '6'
+    - '7'
+  - - '8'
+    - '9'
+    - '0'
+    - F12
+    - {t: ▽, type: trans}
+    - Gui+Ctl+Sft+4
+    - CAPS
+    - '&max_mac'
+    - HOME
+    - PG UP
+  - - LEFT
+    - DOWN
+    - UP
+    - RIGHT
+    - Ctl+LEFT
+    - Ctl+RIGHT
+    - {t: ▽, type: trans}
+    - '&ter_mac'
+    - Gui+SPACE
+    - '&min_mac'
+  - - END
+    - PG DN
+    - {t: Windows, h: toggle}
+    - {t: Game, h: toggle}
+    - VOL DN
+    - VOL UP
+    - PREV
+    - NEXT
+    - Gui+Ctl+Sft+5
+    - ''
+  - - {t: ▽, type: trans}
+    - {t: ▽, type: trans}
+    - {t: ▽, type: trans}
+    - {t: ▽, type: trans}
+    - {t: ▽, type: trans}
+    - {type: held}
+    - {t: ▽, type: trans}
+    - {t: ▽, type: trans}
+  Game:
+  - [ESC, '1', '2', '3', '4', '5', '', '', '', '']
+  - ['', '', '', Q, '', W, E, R, '', '']
+  - ['', '', '', '', LCTRL, LSHFT, A, S, D, '']
+  - - ''
+    - {t: Windows, h: toggle}
+    - {t: MacOS, h: toggle}
+    - ''
+    - ''
+    - ''
+    - G
+    - '6'
+    - '7'
+    - '8'
+  - - '9'
+    - '0'
+    - B
+    - {t: Windows, h: toggle}
+    - ''
+    - ''
+    - ''
+    - ''
+    - ''
+    - ''
+  - - TAB
+    - M
+    - Z
+    - SPACE
+    - {t: System, h: toggle}
+    - ''
+    - ''
+    - ''
+  System:
+  - - ''
+    - ''
+    - ''
+    - ''
+    - ''
+    - BT CLR
+    - {t: BT, h: '0'}
+    - {t: BT, h: '1'}
+    - {t: BT, h: '2'}
+    - {t: BT, h: '3'}
+  - - {t: BT, h: '4'}
+    - ''
+    - ''
+    - ''
+    - ''
+    - ''
+    - ''
+    - ''
+    - ''
+    - ''
+  - ['', '', '', '', '', '', '', '', '', '&bootloader']
+  - - '&bootloader'
+    - {t: Windows, h: toggle}
+    - {t: MacOS, h: toggle}
+    - ''
+    - ''
+    - ''
+    - ''
+    - ''
+    - ''
+    - ''
+  - - ''
+    - '&sys_reset'
+    - ''
+    - {t: Game, h: toggle}
+    - '&sys_reset'
+    - ''
+    - ''
+    - ''
+    - ''
+    - ''
+  - ['', '', '', '', '', '', '', '']


### PR DESCRIPTION
- 從 SVG 檔案中移除深色模式媒體查詢樣式，以清理 CSS。
- 新增 Python 腳本，利用外部鍵盤映射工具生成 YAML 鍵盤映射及對應的 SVG 鍵盤映射視覺化。
- 新增完整的 YAML 鍵盤映射配置，包含多層架構，支援不同作業系統模式及遊戲模式，支援切換與自訂按鍵綁定。

Signed-off-by: WSL <jackie@dast.tw>
