### PR TITLE
refactor: 透過統一 Control 鍵使用方式來釐清快捷鍵綁定

### DIFF
--- a/IMG/lily58.svg
+++ b/IMG/lily58.svg
@@ -1479,7 +1479,9 @@ path.combo {
 </g>
 <g transform="translate(196, 140)" class="key keypos-27">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap"><tspan style="font-size: 88%">&amp;max_mac</tspan></text>
+<text x="0" y="0" class="key tap">
+<tspan x="0" dy="-0.6em">Ctl+Ctl</tspan><tspan x="0" dy="1.2em">+F</tspan>
+</text>
 </g>
 <g transform="translate(252, 147)" class="key keypos-28">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -1535,7 +1537,7 @@ path.combo {
 </g>
 <g transform="translate(196, 196)" class="key keypos-39">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap"><tspan style="font-size: 88%">&amp;min_mac</tspan></text>
+<text x="0" y="0" class="key tap">Ctl+M</text>
 </g>
 <g transform="translate(252, 203)" class="key keypos-40">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -56,34 +56,6 @@
                 <&kp G &kp H &kp O &kp S &kp T &kp T &kp Y &kp RET>;
         };
 
-        max_mac: windowmax_mac {
-            compatible = "zmk,behavior-macro";
-            #binding-cells = <0>;
-            wait-ms = <0>;
-            tap-ms = <0>;
-            bindings =
-                <&macro_press>,
-                <&kp GLOBE>,
-                <&macro_tap>,
-                <&kp F>,
-                <&macro_release>,
-                <&kp GLOBE>;
-        };
-
-        min_mac: windowmin_mac {
-            compatible = "zmk,behavior-macro";
-            #binding-cells = <0>;
-            wait-ms = <0>;
-            tap-ms = <0>;
-            bindings =
-                <&macro_press>,
-                <&kp GLOBE &kp LCTRL>,
-                <&macro_tap>,
-                <&kp F>,
-                <&macro_release>,
-                <&kp GLOBE &kp LCTRL>;
-        };
-
         edge: start_edge {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
@@ -201,11 +173,11 @@
             label = "MacNav";
             display-name = "MacNAV";
             bindings = <
-&trans  &kp F1              &kp F2         &kp F3    &kp F4    &kp F5                             &kp F6        &kp F7        &kp F8      &kp F9      &kp F10             &kp F11
-&trans  &kp N1              &kp N2         &kp N3    &kp N4    &kp N5                             &kp N6        &kp N7        &kp N8      &kp N9      &kp N0              &kp F12
-&trans  &kp LG(LC(LS(N4)))  &kp CAPS       &max_mac  &kp HOME  &kp PG_UP                          &kp LEFT      &kp DOWN      &kp UP      &kp RIGHT   &kp LC(LEFT)        &kp LC(RIGHT)
-&trans  &ter_mac            &kp LG(SPACE)  &min_mac  &kp END   &kp PG_DN  &to WinDef    &to Game  &kp C_VOL_DN  &kp C_VOL_UP  &kp C_PREV  &kp C_NEXT  &kp LG(LC(LS(N5)))  &none
-                                           &trans    &trans    &trans     &trans        &trans    &trans        &trans        &trans
+&trans  &kp F1              &kp F2         &kp F3         &kp F4    &kp F5                             &kp F6        &kp F7        &kp F8      &kp F9      &kp F10             &kp F11
+&trans  &kp N1              &kp N2         &kp N3         &kp N4    &kp N5                             &kp N6        &kp N7        &kp N8      &kp N9      &kp N0              &kp F12
+&trans  &kp LG(LC(LS(N4)))  &kp CAPS       &kp LC(LC(F))  &kp HOME  &kp PG_UP                          &kp LEFT      &kp DOWN      &kp UP      &kp RIGHT   &kp LC(LEFT)        &kp LC(RIGHT)
+&trans  &ter_mac            &kp LG(SPACE)  &kp LC(M)      &kp END   &kp PG_DN  &to WinDef    &to Game  &kp C_VOL_DN  &kp C_VOL_UP  &kp C_PREV  &kp C_NEXT  &kp LG(LC(LS(N5)))  &none
+                                           &trans         &trans    &trans     &trans        &trans    &trans        &trans        &trans
             >;
         };
 


### PR DESCRIPTION
- 在鍵盤 SVG 中，將佔位符按鍵標籤替換為明確的 Control 鍵組合。
- 從按鍵映射設定中移除自訂巨集行為 max_mac 與 min_mac。
- 將按鍵映射中對 max_mac 與 min_mac 的引用替換為標準 Control+F 與 Control+M 鍵碼。

Signed-off-by: Macbook Air <jackie@dast.tw>
