### PR TITLE
修正：更正 keymap 文件中的鍵標籤及修改鍵序列

### DIFF
--- a/IMG/lily58.svg
+++ b/IMG/lily58.svg
@@ -1480,7 +1480,7 @@ path.combo {
 <g transform="translate(196, 140)" class="key keypos-27">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">
-<tspan x="0" dy="-0.6em">Ctl+Ctl</tspan><tspan x="0" dy="1.2em">+F</tspan>
+<tspan x="0" dy="-0.6em">Ctl+Gui</tspan><tspan x="0" dy="1.2em">+F</tspan>
 </text>
 </g>
 <g transform="translate(252, 147)" class="key keypos-28">

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -175,7 +175,7 @@
             bindings = <
 &trans  &kp F1              &kp F2         &kp F3         &kp F4    &kp F5                             &kp F6        &kp F7        &kp F8      &kp F9      &kp F10             &kp F11
 &trans  &kp N1              &kp N2         &kp N3         &kp N4    &kp N5                             &kp N6        &kp N7        &kp N8      &kp N9      &kp N0              &kp F12
-&trans  &kp LG(LC(LS(N4)))  &kp CAPS       &kp LC(LC(F))  &kp HOME  &kp PG_UP                          &kp LEFT      &kp DOWN      &kp UP      &kp RIGHT   &kp LC(LEFT)        &kp LC(RIGHT)
+&trans  &kp LG(LC(LS(N4)))  &kp CAPS       &kp LC(LG(F))  &kp HOME  &kp PG_UP                          &kp LEFT      &kp DOWN      &kp UP      &kp RIGHT   &kp LC(LEFT)        &kp LC(RIGHT)
 &trans  &ter_mac            &kp LG(SPACE)  &kp LC(M)      &kp END   &kp PG_DN  &to WinDef    &to Game  &kp C_VOL_DN  &kp C_VOL_UP  &kp C_PREV  &kp C_NEXT  &kp LG(LC(LS(N5)))  &none
                                            &trans         &trans    &trans     &trans        &trans    &trans        &trans        &trans
             >;


### PR DESCRIPTION
- 將 SVG 鍵標籤從「Ctl+Ctl」更新為「Ctl+Gui」，同時保留「+F」的子標籤。
- 修正 lily58 keymap 配置中的鍵位映射，將修改鍵序列從 LC(LC(F)) 改為 LC(LG(F))。

Signed-off-by: Macbook Air <jackie@dast.tw>
