### PR TITLE
修正：將按鍵映射及標籤從 Control 更新為 GUI 修飾鍵

### DIFF
--- a/IMG/lily58.svg
+++ b/IMG/lily58.svg
@@ -1537,7 +1537,7 @@ path.combo {
 </g>
 <g transform="translate(196, 196)" class="key keypos-39">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">Ctl+M</text>
+<text x="0" y="0" class="key tap">Gui+M</text>
 </g>
 <g transform="translate(252, 203)" class="key keypos-40">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -176,7 +176,7 @@
 &trans  &kp F1              &kp F2         &kp F3         &kp F4    &kp F5                             &kp F6        &kp F7        &kp F8      &kp F9      &kp F10             &kp F11
 &trans  &kp N1              &kp N2         &kp N3         &kp N4    &kp N5                             &kp N6        &kp N7        &kp N8      &kp N9      &kp N0              &kp F12
 &trans  &kp LG(LC(LS(N4)))  &kp CAPS       &kp LC(LG(F))  &kp HOME  &kp PG_UP                          &kp LEFT      &kp DOWN      &kp UP      &kp RIGHT   &kp LC(LEFT)        &kp LC(RIGHT)
-&trans  &ter_mac            &kp LG(SPACE)  &kp LC(M)      &kp END   &kp PG_DN  &to WinDef    &to Game  &kp C_VOL_DN  &kp C_VOL_UP  &kp C_PREV  &kp C_NEXT  &kp LG(LC(LS(N5)))  &none
+&trans  &ter_mac            &kp LG(SPACE)  &kp LG(M)      &kp END   &kp PG_DN  &to WinDef    &to Game  &kp C_VOL_DN  &kp C_VOL_UP  &kp C_PREV  &kp C_NEXT  &kp LG(LC(LS(N5)))  &none
                                            &trans         &trans    &trans     &trans        &trans    &trans        &trans        &trans
             >;
         };


### PR DESCRIPTION
- 將 SVG 圖像中顯示的按鍵標籤從「Ctl+M」更新為「Gui+M」。
- 在按鍵映射設定中，將一個按鍵映射從左 Control + M 改為左 GUI + M。

Signed-off-by: Macbook Air <jackie@dast.tw>
