### PR TITLE
feat: 在巨集設定中於返回鍵前插入特定按鍵序列

### DIFF
--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -53,7 +53,7 @@
                 <&kp LCMD>,
                 <&macro_pause_for_release>,
                 <&macro_tap>,
-                <&kp G &kp H &kp O &kp S &kp T &kp T &kp Y &kp RET>;
+                <&kp G &kp H &kp O &kp S &kp T &kp T &kp Y  &kp DOT &kp A &kp P &kp P &kp RET>;
         };
 
         edge: start_edge {


### PR DESCRIPTION
- 在按鍵對應設定中的巨集裡，於返回鍵前新增一組按鍵序列（DOT A P P）。

Signed-off-by: Macbook Air <jackie@dast.tw>
