### PR TITLE
修正：更正滾動鍵標籤並新增滑鼠輸入行為

### DIFF
--- a/IMG/lily58.svg
+++ b/IMG/lily58.svg
@@ -1670,7 +1670,7 @@ path.combo {
 <g transform="translate(196, 84)" class="key keypos-15">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">
-<tspan x="0" dy="-0.6em" style="font-size: 88%">&amp;msc</tspan><tspan x="0" dy="1.2em" style="font-size: 88%">SWCRL_UP</tspan>
+<tspan x="0" dy="-0.6em">&amp;msc</tspan><tspan x="0" dy="1.2em">SCRL_UP</tspan>
 </text>
 </g>
 <g transform="translate(252, 91)" class="key keypos-16">

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -21,6 +21,23 @@
 #define SYS      8
 
 / {
+   behaviors {
+       mouse_movement: mouse_movement {
+           compatible = "zmk,behavior-mouse-move";
+           #binding-cells = <1>;
+       };
+
+       mouse_click: mouse_click {
+           compatible = "zmk,behavior-mouse-click";
+           #binding-cells = <1>;
+       };
+
+       mouse_scroll: mouse_scroll {
+           compatible = "zmk,behavior-mouse-scroll";
+           #binding-cells = <1>;
+       };
+   };
+
    macros {
         ter_wsl: terminal_windows {
             compatible = "zmk,behavior-macro";
@@ -186,7 +203,7 @@
             display-name = "Mouse";
             bindings = <
 &none  &none  &none           &none           &none            &none                            &none           &none           &none         &none            &none  &none
-&none  &none  &none           &msc SWCRL_UP   &none            &none                            &none           &none           &none         &none            &none  &none
+&none  &none  &none           &msc SCRL_UP    &none            &none                            &none           &none           &none         &none            &none  &none
 &none  &none  &msc SCRL_LEFT  &msc SCRL_DOWN  &msc SCRL_RIGHT  &none                            &mmv MOVE_LEFT  &mmv MOVE_DOWN  &mmv MOVE_UP  &mmv MOVE_RIGHT  &none  &none
 &none  &none  &none           &none           &none            &none  &to MacDef    &to WinDef  &none           &none           &none         &none            &none  &none
                               &none           &none            &none  &mkp MB1      &mkp MB3    &mkp MB2        &none           &none


### PR DESCRIPTION
- 將 SVG 標籤文字從「SWCRL_UP」更新為「SCRL_UP」，以更正或簡化鍵位標籤。
- 在鍵盤映射配置中新增滑鼠相關行為（滑鼠移動、點擊及滾動）。
- 將鍵盤映射中的「SWCRL_UP」綁定替換為「SCRL_UP」，以符合更新後的標籤。

Signed-off-by: Macbook Air <jackie@dast.tw>
