### PR TITLE
feat: 改善滑鼠操作標籤並重新排列快捷鍵綁定

### DIFF
--- a/IMG/lily58.svg
+++ b/IMG/lily58.svg
@@ -1669,9 +1669,6 @@ path.combo {
 </g>
 <g transform="translate(196, 84)" class="key keypos-15">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">
-<tspan x="0" dy="-0.6em">&amp;msc</tspan><tspan x="0" dy="1.2em">SCRL_UP</tspan>
-</text>
 </g>
 <g transform="translate(252, 91)" class="key keypos-16">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -1681,15 +1678,27 @@ path.combo {
 </g>
 <g transform="translate(616, 98)" class="key keypos-18">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">
+<tspan x="0" dy="-0.6em" style="font-size: 78%">&amp;msc</tspan><tspan x="0" dy="1.2em" style="font-size: 78%">SCRL_LEFT</tspan>
+</text>
 </g>
 <g transform="translate(672, 91)" class="key keypos-19">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">
+<tspan x="0" dy="-0.6em" style="font-size: 78%">&amp;msc</tspan><tspan x="0" dy="1.2em" style="font-size: 78%">SCRL_DOWN</tspan>
+</text>
 </g>
 <g transform="translate(728, 84)" class="key keypos-20">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">
+<tspan x="0" dy="-0.6em">&amp;msc</tspan><tspan x="0" dy="1.2em">SCRL_UP</tspan>
+</text>
 </g>
 <g transform="translate(784, 91)" class="key keypos-21">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">
+<tspan x="0" dy="-0.6em" style="font-size: 70%">&amp;msc</tspan><tspan x="0" dy="1.2em" style="font-size: 70%">SCRL_RIGHT</tspan>
+</text>
 </g>
 <g transform="translate(840, 105)" class="key keypos-22">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -1705,21 +1714,12 @@ path.combo {
 </g>
 <g transform="translate(140, 147)" class="key keypos-26">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">
-<tspan x="0" dy="-0.6em" style="font-size: 78%">&amp;msc</tspan><tspan x="0" dy="1.2em" style="font-size: 78%">SCRL_LEFT</tspan>
-</text>
 </g>
 <g transform="translate(196, 140)" class="key keypos-27">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">
-<tspan x="0" dy="-0.6em" style="font-size: 78%">&amp;msc</tspan><tspan x="0" dy="1.2em" style="font-size: 78%">SCRL_DOWN</tspan>
-</text>
 </g>
 <g transform="translate(252, 147)" class="key keypos-28">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">
-<tspan x="0" dy="-0.6em" style="font-size: 70%">&amp;msc</tspan><tspan x="0" dy="1.2em" style="font-size: 70%">SCRL_RIGHT</tspan>
-</text>
 </g>
 <g transform="translate(308, 154)" class="key keypos-29">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -1786,6 +1786,9 @@ path.combo {
 </g>
 <g transform="translate(616, 210)" class="key keypos-44">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">
+<tspan x="0" dy="-0.6em">&amp;mkp</tspan><tspan x="0" dy="1.2em">MB2</tspan>
+</text>
 </g>
 <g transform="translate(672, 203)" class="key keypos-45">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -1813,20 +1816,17 @@ path.combo {
 </g>
 <g transform="translate(350, 266) rotate(30.0)" class="key keypos-53">
 <rect rx="6" ry="6" x="-26" y="-40" width="52" height="80" class="key"/>
-<text x="0" y="0" class="key tap">
-<tspan x="0" dy="-0.6em">&amp;mkp</tspan><tspan x="0" dy="1.2em">MB1</tspan>
-</text>
 </g>
 <g transform="translate(574, 266) rotate(-30.0)" class="key keypos-54">
 <rect rx="6" ry="6" x="-26" y="-40" width="52" height="80" class="key"/>
 <text x="0" y="0" class="key tap">
-<tspan x="0" dy="-0.6em">&amp;mkp</tspan><tspan x="0" dy="1.2em">MB3</tspan>
+<tspan x="0" dy="-0.6em">&amp;mkp</tspan><tspan x="0" dy="1.2em">MB1</tspan>
 </text>
 </g>
 <g transform="translate(644, 266)" class="key keypos-55">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">
-<tspan x="0" dy="-0.6em">&amp;mkp</tspan><tspan x="0" dy="1.2em">MB2</tspan>
+<tspan x="0" dy="-0.6em">&amp;mkp</tspan><tspan x="0" dy="1.2em">MB3</tspan>
 </text>
 </g>
 <g transform="translate(700, 260)" class="key keypos-56">

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -22,19 +22,22 @@
 
 / {
    behaviors {
-       mouse_movement: mouse_movement {
+       // 滑鼠移動
+       mmv: mouse_movement {
            compatible = "zmk,behavior-mouse-move";
-           #binding-cells = <1>;
+           #binding-cells = <1>; // 1 個參數表示方向
        };
 
-       mouse_click: mouse_click {
+       // 滑鼠點擊
+       mkp: mouse_click {
            compatible = "zmk,behavior-mouse-click";
-           #binding-cells = <1>;
+           #binding-cells = <1>; // 1 個參數表示按鍵 (1=左,2=右,3=中)
        };
 
-       mouse_scroll: mouse_scroll {
+       // 滑鼠滾輪
+       msc: mouse_scroll {
            compatible = "zmk,behavior-mouse-scroll";
-           #binding-cells = <1>;
+           #binding-cells = <1>; // 1 個參數表示方向
        };
    };
 
@@ -202,11 +205,11 @@
             label = "Mouse";
             display-name = "Mouse";
             bindings = <
-&none  &none  &none           &none           &none            &none                            &none           &none           &none         &none            &none  &none
-&none  &none  &none           &msc SCRL_UP    &none            &none                            &none           &none           &none         &none            &none  &none
-&none  &none  &msc SCRL_LEFT  &msc SCRL_DOWN  &msc SCRL_RIGHT  &none                            &mmv MOVE_LEFT  &mmv MOVE_DOWN  &mmv MOVE_UP  &mmv MOVE_RIGHT  &none  &none
-&none  &none  &none           &none           &none            &none  &to MacDef    &to WinDef  &none           &none           &none         &none            &none  &none
-                              &none           &none            &none  &mkp MB1      &mkp MB3    &mkp MB2        &none           &none
+&none  &none  &none  &none  &none  &none                            &none           &none           &none         &none            &none  &none
+&none  &none  &none  &none  &none  &none                            &msc SCRL_LEFT  &msc SCRL_DOWN  &msc SCRL_UP  &msc SCRL_RIGHT  &none  &none
+&none  &none  &none  &none  &none  &none                            &mmv MOVE_LEFT  &mmv MOVE_DOWN  &mmv MOVE_UP  &mmv MOVE_RIGHT  &none  &none
+&none  &none  &none  &none  &none  &none  &to MacDef    &to WinDef  &mkp MB2        &none           &none         &none            &none  &none
+                     &none  &none  &none  &none         &mkp MB1    &mkp MB3        &none           &none
             >;
         };
 


### PR DESCRIPTION
- 在 SVG 佈局中的多個鍵位新增滑鼠滾動標籤，以增強視覺指示。
- 在 SVG 佈局中特定鍵位新增滑鼠按鈕點擊標籤，並相應調整現有標籤。
- 重新命名滑鼠移動、點擊及滾動的行為識別碼，並添加其他語言的註解以便說明。
- 調整快捷鍵綁定，重新排列滑鼠滾動與按鈕點擊的分配，以優化佈局與一致性。

Signed-off-by: Macbook Air <jackie@dast.tw>
