### PR TITLE
重構：優化按鍵標籤並分離巨集點擊與輸入動作

### DIFF
--- a/IMG/lily58.svg
+++ b/IMG/lily58.svg
@@ -1679,25 +1679,25 @@ path.combo {
 <g transform="translate(616, 98)" class="key keypos-18">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">
-<tspan x="0" dy="-0.6em" style="font-size: 78%">&amp;msc</tspan><tspan x="0" dy="1.2em" style="font-size: 78%">SCRL_LEFT</tspan>
+<tspan x="0" dy="-1.2em" style="font-size: 70%">&amp;msc</tspan><tspan x="0" dy="1.2em" style="font-size: 70%">(SCRL_LEFT</tspan><tspan x="0" dy="1.2em" style="font-size: 70%">)</tspan>
 </text>
 </g>
 <g transform="translate(672, 91)" class="key keypos-19">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">
-<tspan x="0" dy="-0.6em" style="font-size: 78%">&amp;msc</tspan><tspan x="0" dy="1.2em" style="font-size: 78%">SCRL_DOWN</tspan>
+<tspan x="0" dy="-1.2em" style="font-size: 70%">&amp;msc</tspan><tspan x="0" dy="1.2em" style="font-size: 70%">(SCRL_DOWN</tspan><tspan x="0" dy="1.2em" style="font-size: 70%">)</tspan>
 </text>
 </g>
 <g transform="translate(728, 84)" class="key keypos-20">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">
-<tspan x="0" dy="-0.6em">&amp;msc</tspan><tspan x="0" dy="1.2em">SCRL_UP</tspan>
+<tspan x="0" dy="-1.2em" style="font-size: 88%">&amp;msc</tspan><tspan x="0" dy="1.2em" style="font-size: 88%">(SCRL_UP</tspan><tspan x="0" dy="1.2em" style="font-size: 88%">)</tspan>
 </text>
 </g>
 <g transform="translate(784, 91)" class="key keypos-21">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">
-<tspan x="0" dy="-0.6em" style="font-size: 70%">&amp;msc</tspan><tspan x="0" dy="1.2em" style="font-size: 70%">SCRL_RIGHT</tspan>
+<tspan x="0" dy="-1.2em" style="font-size: 64%">&amp;msc</tspan><tspan x="0" dy="1.2em" style="font-size: 64%">(SCRL_RIGHT</tspan><tspan x="0" dy="1.2em" style="font-size: 64%">)</tspan>
 </text>
 </g>
 <g transform="translate(840, 105)" class="key keypos-22">
@@ -1727,25 +1727,25 @@ path.combo {
 <g transform="translate(616, 154)" class="key keypos-30">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">
-<tspan x="0" dy="-0.6em" style="font-size: 78%">&amp;mmv</tspan><tspan x="0" dy="1.2em" style="font-size: 78%">MOVE_LEFT</tspan>
+<tspan x="0" dy="-1.2em" style="font-size: 70%">&amp;mmv</tspan><tspan x="0" dy="1.2em" style="font-size: 70%">(MOVE_LEFT</tspan><tspan x="0" dy="1.2em" style="font-size: 70%">)</tspan>
 </text>
 </g>
 <g transform="translate(672, 147)" class="key keypos-31">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">
-<tspan x="0" dy="-0.6em" style="font-size: 78%">&amp;mmv</tspan><tspan x="0" dy="1.2em" style="font-size: 78%">MOVE_DOWN</tspan>
+<tspan x="0" dy="-1.2em" style="font-size: 70%">&amp;mmv</tspan><tspan x="0" dy="1.2em" style="font-size: 70%">(MOVE_DOWN</tspan><tspan x="0" dy="1.2em" style="font-size: 70%">)</tspan>
 </text>
 </g>
 <g transform="translate(728, 140)" class="key keypos-32">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">
-<tspan x="0" dy="-0.6em">&amp;mmv</tspan><tspan x="0" dy="1.2em">MOVE_UP</tspan>
+<tspan x="0" dy="-1.2em" style="font-size: 88%">&amp;mmv</tspan><tspan x="0" dy="1.2em" style="font-size: 88%">(MOVE_UP</tspan><tspan x="0" dy="1.2em" style="font-size: 88%">)</tspan>
 </text>
 </g>
 <g transform="translate(784, 147)" class="key keypos-33">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">
-<tspan x="0" dy="-0.6em" style="font-size: 70%">&amp;mmv</tspan><tspan x="0" dy="1.2em" style="font-size: 70%">MOVE_RIGHT</tspan>
+<tspan x="0" dy="-1.2em" style="font-size: 64%">&amp;mmv</tspan><tspan x="0" dy="1.2em" style="font-size: 64%">(MOVE_RIGHT</tspan><tspan x="0" dy="1.2em" style="font-size: 64%">)</tspan>
 </text>
 </g>
 <g transform="translate(840, 161)" class="key keypos-34">

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -73,7 +73,8 @@
                 <&kp LCMD>,
                 <&macro_pause_for_release>,
                 <&macro_tap>,
-                <&kp G &kp H &kp O &kp S &kp T &kp T &kp Y  &kp DOT &kp A &kp P &kp P &kp RET>;
+                <&kp G &kp H &kp O &kp S &kp T &kp T &kp Y  &kp DOT &kp A &kp P &kp P>,
+                <&macro_tap &kp ENTER>;
         };
 
         edge: start_edge {
@@ -205,11 +206,11 @@
             label = "Mouse";
             display-name = "Mouse";
             bindings = <
-&none  &none  &none  &none  &none  &none                            &none           &none           &none         &none            &none  &none
-&none  &none  &none  &none  &none  &none                            &msc SCRL_LEFT  &msc SCRL_DOWN  &msc SCRL_UP  &msc SCRL_RIGHT  &none  &none
-&none  &none  &none  &none  &none  &none                            &mmv MOVE_LEFT  &mmv MOVE_DOWN  &mmv MOVE_UP  &mmv MOVE_RIGHT  &none  &none
-&none  &none  &none  &none  &none  &none  &to MacDef    &to WinDef  &mkp MB2        &none           &none         &none            &none  &none
-                     &none  &none  &none  &none         &mkp MB1    &mkp MB3        &none           &none
+&none  &none  &none  &none  &none  &none                            &none             &none             &none           &none              &none  &none
+&none  &none  &none  &none  &none  &none                            &msc (SCRL_LEFT)  &msc (SCRL_DOWN)  &msc (SCRL_UP)  &msc (SCRL_RIGHT)  &none  &none
+&none  &none  &none  &none  &none  &none                            &mmv (MOVE_LEFT)  &mmv (MOVE_DOWN)  &mmv (MOVE_UP)  &mmv (MOVE_RIGHT)  &none  &none
+&none  &none  &none  &none  &none  &none  &to MacDef    &to WinDef  &mkp MB2          &none             &none           &none              &none  &none
+                     &none  &none  &none  &none         &mkp MB1    &mkp MB3          &none             &none
             >;
         };
 


### PR DESCRIPTION
- 更新 SVG 按鍵標籤，於捲動及移動鍵名稱外加上括號，並略微調整字體大小以提高清晰度。
- 修改鍵盤映射綁定，通過在捲動與移動動作周圍加入括號來反映更新後的按鍵標籤。
- 將原先合併的巨集點擊與輸入按鍵行為分離為獨立的巨集點擊與輸入動作，以改善按鍵行為。

Signed-off-by: Macbook Air <jackie@dast.tw>
