### PR TITLE
style: 在 UI 和 keymap 中的滾動與移動鍵使用尖括號

### DIFF
--- a/IMG/lily58.svg
+++ b/IMG/lily58.svg
@@ -1679,25 +1679,25 @@ path.combo {
 <g transform="translate(616, 98)" class="key keypos-18">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">
-<tspan x="0" dy="-1.2em" style="font-size: 70%">&amp;msc</tspan><tspan x="0" dy="1.2em" style="font-size: 70%">(SCRL_LEFT</tspan><tspan x="0" dy="1.2em" style="font-size: 70%">)</tspan>
+<tspan x="0" dy="-1.2em" style="font-size: 70%">&amp;msc</tspan><tspan x="0" dy="1.2em" style="font-size: 70%">&lt;SCRL_LEFT</tspan><tspan x="0" dy="1.2em" style="font-size: 70%">&gt;</tspan>
 </text>
 </g>
 <g transform="translate(672, 91)" class="key keypos-19">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">
-<tspan x="0" dy="-1.2em" style="font-size: 70%">&amp;msc</tspan><tspan x="0" dy="1.2em" style="font-size: 70%">(SCRL_DOWN</tspan><tspan x="0" dy="1.2em" style="font-size: 70%">)</tspan>
+<tspan x="0" dy="-1.2em" style="font-size: 70%">&amp;msc</tspan><tspan x="0" dy="1.2em" style="font-size: 70%">&lt;SCRL_DOWN</tspan><tspan x="0" dy="1.2em" style="font-size: 70%">&gt;</tspan>
 </text>
 </g>
 <g transform="translate(728, 84)" class="key keypos-20">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">
-<tspan x="0" dy="-1.2em" style="font-size: 88%">&amp;msc</tspan><tspan x="0" dy="1.2em" style="font-size: 88%">(SCRL_UP</tspan><tspan x="0" dy="1.2em" style="font-size: 88%">)</tspan>
+<tspan x="0" dy="-1.2em" style="font-size: 88%">&amp;msc</tspan><tspan x="0" dy="1.2em" style="font-size: 88%">&lt;SCRL_UP</tspan><tspan x="0" dy="1.2em" style="font-size: 88%">&gt;</tspan>
 </text>
 </g>
 <g transform="translate(784, 91)" class="key keypos-21">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">
-<tspan x="0" dy="-1.2em" style="font-size: 64%">&amp;msc</tspan><tspan x="0" dy="1.2em" style="font-size: 64%">(SCRL_RIGHT</tspan><tspan x="0" dy="1.2em" style="font-size: 64%">)</tspan>
+<tspan x="0" dy="-1.2em" style="font-size: 64%">&amp;msc</tspan><tspan x="0" dy="1.2em" style="font-size: 64%">&lt;SCRL_RIGHT</tspan><tspan x="0" dy="1.2em" style="font-size: 64%">&gt;</tspan>
 </text>
 </g>
 <g transform="translate(840, 105)" class="key keypos-22">
@@ -1727,25 +1727,25 @@ path.combo {
 <g transform="translate(616, 154)" class="key keypos-30">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">
-<tspan x="0" dy="-1.2em" style="font-size: 70%">&amp;mmv</tspan><tspan x="0" dy="1.2em" style="font-size: 70%">(MOVE_LEFT</tspan><tspan x="0" dy="1.2em" style="font-size: 70%">)</tspan>
+<tspan x="0" dy="-1.2em" style="font-size: 70%">&amp;mmv</tspan><tspan x="0" dy="1.2em" style="font-size: 70%">&lt;MOVE_LEFT</tspan><tspan x="0" dy="1.2em" style="font-size: 70%">&gt;</tspan>
 </text>
 </g>
 <g transform="translate(672, 147)" class="key keypos-31">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">
-<tspan x="0" dy="-1.2em" style="font-size: 70%">&amp;mmv</tspan><tspan x="0" dy="1.2em" style="font-size: 70%">(MOVE_DOWN</tspan><tspan x="0" dy="1.2em" style="font-size: 70%">)</tspan>
+<tspan x="0" dy="-1.2em" style="font-size: 70%">&amp;mmv</tspan><tspan x="0" dy="1.2em" style="font-size: 70%">&lt;MOVE_DOWN</tspan><tspan x="0" dy="1.2em" style="font-size: 70%">&gt;</tspan>
 </text>
 </g>
 <g transform="translate(728, 140)" class="key keypos-32">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">
-<tspan x="0" dy="-1.2em" style="font-size: 88%">&amp;mmv</tspan><tspan x="0" dy="1.2em" style="font-size: 88%">(MOVE_UP</tspan><tspan x="0" dy="1.2em" style="font-size: 88%">)</tspan>
+<tspan x="0" dy="-1.2em" style="font-size: 88%">&amp;mmv</tspan><tspan x="0" dy="1.2em" style="font-size: 88%">&lt;MOVE_UP</tspan><tspan x="0" dy="1.2em" style="font-size: 88%">&gt;</tspan>
 </text>
 </g>
 <g transform="translate(784, 147)" class="key keypos-33">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">
-<tspan x="0" dy="-1.2em" style="font-size: 64%">&amp;mmv</tspan><tspan x="0" dy="1.2em" style="font-size: 64%">(MOVE_RIGHT</tspan><tspan x="0" dy="1.2em" style="font-size: 64%">)</tspan>
+<tspan x="0" dy="-1.2em" style="font-size: 64%">&amp;mmv</tspan><tspan x="0" dy="1.2em" style="font-size: 64%">&lt;MOVE_RIGHT</tspan><tspan x="0" dy="1.2em" style="font-size: 64%">&gt;</tspan>
 </text>
 </g>
 <g transform="translate(840, 161)" class="key keypos-34">

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -207,8 +207,8 @@
             display-name = "Mouse";
             bindings = <
 &none  &none  &none  &none  &none  &none                            &none             &none             &none           &none              &none  &none
-&none  &none  &none  &none  &none  &none                            &msc (SCRL_LEFT)  &msc (SCRL_DOWN)  &msc (SCRL_UP)  &msc (SCRL_RIGHT)  &none  &none
-&none  &none  &none  &none  &none  &none                            &mmv (MOVE_LEFT)  &mmv (MOVE_DOWN)  &mmv (MOVE_UP)  &mmv (MOVE_RIGHT)  &none  &none
+&none  &none  &none  &none  &none  &none                            &msc <SCRL_LEFT>  &msc <SCRL_DOWN>  &msc <SCRL_UP>  &msc <SCRL_RIGHT>  &none  &none
+&none  &none  &none  &none  &none  &none                            &mmv <MOVE_LEFT>  &mmv <MOVE_DOWN>  &mmv <MOVE_UP>  &mmv <MOVE_RIGHT>  &none  &none
 &none  &none  &none  &none  &none  &none  &to MacDef    &to WinDef  &mkp MB2          &none             &none           &none              &none  &none
                      &none  &none  &none  &none         &mkp MB1    &mkp MB3          &none             &none
             >;


### PR DESCRIPTION
- 將 SVG 中滾動與移動鍵標籤的括號由圓括號替換為尖括號，以提升清晰度。
- 更新 keymap 綁定，將滾動與移動鍵的括號由圓括號改為尖括號，以符合 SVG 標籤風格。

Signed-off-by: Macbook Air <jackie@dast.tw>
