### PR TITLE
重構：從 SVG 鍵盤映射和設定中移除所有滑鼠圖層及綁定

### DIFF
--- a/IMG/lily58.svg
+++ b/IMG/lily58.svg
@@ -1,4 +1,4 @@
-<svg width="984" height="3407" viewBox="0 0 984 3407" class="keymap" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="984" height="3035" viewBox="0 0 984 3035" class="keymap" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
 <style>/* inherit to force styles through use tags */
 svg path {
     fill: inherit;
@@ -364,9 +364,6 @@ path.combo {
 </g>
 <g transform="translate(756, 260)" class="key keypos-57">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<a href="#Mouse">
-<text x="0" y="0" class="key tap layer-activator">Mouse</text>
-</a><text x="0" y="24" class="key hold">toggle</text>
 </g>
 </g>
 </g>
@@ -1112,9 +1109,6 @@ path.combo {
 </g>
 <g transform="translate(756, 260)" class="key keypos-57">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<a href="#Mouse">
-<text x="0" y="0" class="key tap layer-activator">Mouse</text>
-</a><text x="0" y="24" class="key hold">toggle</text>
 </g>
 </g>
 </g>
@@ -1619,225 +1613,7 @@ path.combo {
 </g>
 </g>
 </g>
-<g transform="translate(30, 2234)" class="layer-Mouse">
-<text x="0" y="28" class="label" id="Mouse">Mouse:</text>
-<g transform="translate(0, 56)">
-<g transform="translate(28, 56)" class="key keypos-0">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-</g>
-<g transform="translate(84, 49)" class="key keypos-1">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-</g>
-<g transform="translate(140, 35)" class="key keypos-2">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-</g>
-<g transform="translate(196, 28)" class="key keypos-3">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-</g>
-<g transform="translate(252, 35)" class="key keypos-4">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-</g>
-<g transform="translate(308, 42)" class="key keypos-5">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-</g>
-<g transform="translate(616, 42)" class="key keypos-6">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-</g>
-<g transform="translate(672, 35)" class="key keypos-7">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-</g>
-<g transform="translate(728, 28)" class="key keypos-8">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-</g>
-<g transform="translate(784, 35)" class="key keypos-9">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-</g>
-<g transform="translate(840, 49)" class="key keypos-10">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-</g>
-<g transform="translate(896, 56)" class="key keypos-11">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-</g>
-<g transform="translate(28, 112)" class="key keypos-12">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-</g>
-<g transform="translate(84, 105)" class="key keypos-13">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-</g>
-<g transform="translate(140, 91)" class="key keypos-14">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-</g>
-<g transform="translate(196, 84)" class="key keypos-15">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-</g>
-<g transform="translate(252, 91)" class="key keypos-16">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-</g>
-<g transform="translate(308, 98)" class="key keypos-17">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-</g>
-<g transform="translate(616, 98)" class="key keypos-18">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">
-<tspan x="0" dy="-1.2em" style="font-size: 70%">&amp;msc</tspan><tspan x="0" dy="1.2em" style="font-size: 70%">&lt;SCRL_LEFT</tspan><tspan x="0" dy="1.2em" style="font-size: 70%">&gt;</tspan>
-</text>
-</g>
-<g transform="translate(672, 91)" class="key keypos-19">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">
-<tspan x="0" dy="-1.2em" style="font-size: 70%">&amp;msc</tspan><tspan x="0" dy="1.2em" style="font-size: 70%">&lt;SCRL_DOWN</tspan><tspan x="0" dy="1.2em" style="font-size: 70%">&gt;</tspan>
-</text>
-</g>
-<g transform="translate(728, 84)" class="key keypos-20">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">
-<tspan x="0" dy="-1.2em" style="font-size: 88%">&amp;msc</tspan><tspan x="0" dy="1.2em" style="font-size: 88%">&lt;SCRL_UP</tspan><tspan x="0" dy="1.2em" style="font-size: 88%">&gt;</tspan>
-</text>
-</g>
-<g transform="translate(784, 91)" class="key keypos-21">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">
-<tspan x="0" dy="-1.2em" style="font-size: 64%">&amp;msc</tspan><tspan x="0" dy="1.2em" style="font-size: 64%">&lt;SCRL_RIGHT</tspan><tspan x="0" dy="1.2em" style="font-size: 64%">&gt;</tspan>
-</text>
-</g>
-<g transform="translate(840, 105)" class="key keypos-22">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-</g>
-<g transform="translate(896, 112)" class="key keypos-23">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-</g>
-<g transform="translate(28, 168)" class="key keypos-24">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-</g>
-<g transform="translate(84, 161)" class="key keypos-25">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-</g>
-<g transform="translate(140, 147)" class="key keypos-26">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-</g>
-<g transform="translate(196, 140)" class="key keypos-27">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-</g>
-<g transform="translate(252, 147)" class="key keypos-28">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-</g>
-<g transform="translate(308, 154)" class="key keypos-29">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-</g>
-<g transform="translate(616, 154)" class="key keypos-30">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">
-<tspan x="0" dy="-1.2em" style="font-size: 70%">&amp;mmv</tspan><tspan x="0" dy="1.2em" style="font-size: 70%">&lt;MOVE_LEFT</tspan><tspan x="0" dy="1.2em" style="font-size: 70%">&gt;</tspan>
-</text>
-</g>
-<g transform="translate(672, 147)" class="key keypos-31">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">
-<tspan x="0" dy="-1.2em" style="font-size: 70%">&amp;mmv</tspan><tspan x="0" dy="1.2em" style="font-size: 70%">&lt;MOVE_DOWN</tspan><tspan x="0" dy="1.2em" style="font-size: 70%">&gt;</tspan>
-</text>
-</g>
-<g transform="translate(728, 140)" class="key keypos-32">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">
-<tspan x="0" dy="-1.2em" style="font-size: 88%">&amp;mmv</tspan><tspan x="0" dy="1.2em" style="font-size: 88%">&lt;MOVE_UP</tspan><tspan x="0" dy="1.2em" style="font-size: 88%">&gt;</tspan>
-</text>
-</g>
-<g transform="translate(784, 147)" class="key keypos-33">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">
-<tspan x="0" dy="-1.2em" style="font-size: 64%">&amp;mmv</tspan><tspan x="0" dy="1.2em" style="font-size: 64%">&lt;MOVE_RIGHT</tspan><tspan x="0" dy="1.2em" style="font-size: 64%">&gt;</tspan>
-</text>
-</g>
-<g transform="translate(840, 161)" class="key keypos-34">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-</g>
-<g transform="translate(896, 168)" class="key keypos-35">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-</g>
-<g transform="translate(28, 224)" class="key keypos-36">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-</g>
-<g transform="translate(84, 217)" class="key keypos-37">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-</g>
-<g transform="translate(140, 203)" class="key keypos-38">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-</g>
-<g transform="translate(196, 196)" class="key keypos-39">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-</g>
-<g transform="translate(252, 203)" class="key keypos-40">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-</g>
-<g transform="translate(308, 210)" class="key keypos-41">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-</g>
-<g transform="translate(364, 182)" class="key keypos-42">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<a href="#MacOS">
-<text x="0" y="0" class="key tap layer-activator">MacOS</text>
-</a><text x="0" y="24" class="key hold">toggle</text>
-</g>
-<g transform="translate(560, 182)" class="key keypos-43">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<a href="#Windows">
-<text x="0" y="0" class="key tap layer-activator">Windows</text>
-</a><text x="0" y="24" class="key hold">toggle</text>
-</g>
-<g transform="translate(616, 210)" class="key keypos-44">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">
-<tspan x="0" dy="-0.6em">&amp;mkp</tspan><tspan x="0" dy="1.2em">MB2</tspan>
-</text>
-</g>
-<g transform="translate(672, 203)" class="key keypos-45">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-</g>
-<g transform="translate(728, 196)" class="key keypos-46">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-</g>
-<g transform="translate(784, 203)" class="key keypos-47">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-</g>
-<g transform="translate(840, 217)" class="key keypos-48">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-</g>
-<g transform="translate(896, 224)" class="key keypos-49">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-</g>
-<g transform="translate(168, 259)" class="key keypos-50">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-</g>
-<g transform="translate(224, 260)" class="key keypos-51">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-</g>
-<g transform="translate(280, 266)" class="key keypos-52">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-</g>
-<g transform="translate(350, 266) rotate(30.0)" class="key keypos-53">
-<rect rx="6" ry="6" x="-26" y="-40" width="52" height="80" class="key"/>
-</g>
-<g transform="translate(574, 266) rotate(-30.0)" class="key keypos-54">
-<rect rx="6" ry="6" x="-26" y="-40" width="52" height="80" class="key"/>
-<text x="0" y="0" class="key tap">
-<tspan x="0" dy="-0.6em">&amp;mkp</tspan><tspan x="0" dy="1.2em">MB1</tspan>
-</text>
-</g>
-<g transform="translate(644, 266)" class="key keypos-55">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">
-<tspan x="0" dy="-0.6em">&amp;mkp</tspan><tspan x="0" dy="1.2em">MB3</tspan>
-</text>
-</g>
-<g transform="translate(700, 260)" class="key keypos-56">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-</g>
-<g transform="translate(756, 260)" class="key keypos-57">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-</g>
-</g>
-</g>
-<g transform="translate(30, 2607)" class="layer-Game">
+<g transform="translate(30, 2234)" class="layer-Game">
 <text x="0" y="28" class="label" id="Game">Game:</text>
 <g transform="translate(0, 56)">
 <g transform="translate(28, 56)" class="key keypos-0">
@@ -2054,7 +1830,7 @@ path.combo {
 </g>
 </g>
 </g>
-<g transform="translate(30, 2979)" class="layer-System">
+<g transform="translate(30, 2607)" class="layer-System">
 <text x="0" y="28" class="label" id="System">System:</text>
 <g transform="translate(0, 56)">
 <g transform="translate(28, 56)" class="key keypos-0">

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -16,31 +16,10 @@
 #define MacDef   3
 #define MacCode  4
 #define MacNav   5
-#define Mouse    6
-#define Game     7
-#define SYS      8
+#define Game     6
+#define SYS      7
 
 / {
-   behaviors {
-       // 滑鼠移動
-       mmv: mouse_movement {
-           compatible = "zmk,behavior-mouse-move";
-           #binding-cells = <1>; // 1 個參數表示方向
-       };
-
-       // 滑鼠點擊
-       mkp: mouse_click {
-           compatible = "zmk,behavior-mouse-click";
-           #binding-cells = <1>; // 1 個參數表示按鍵 (1=左,2=右,3=中)
-       };
-
-       // 滑鼠滾輪
-       msc: mouse_scroll {
-           compatible = "zmk,behavior-mouse-scroll";
-           #binding-cells = <1>; // 1 個參數表示方向
-       };
-   };
-
    macros {
         ter_wsl: terminal_windows {
             compatible = "zmk,behavior-macro";
@@ -138,7 +117,7 @@
 &kp TAB    &kp Q   &kp W   &kp E     &kp R         &kp T                                          &kp Y            &kp U   &kp I      &kp O    &kp P     &kp LC(TAB)
 &kp LCTRL  &kp A   &kp S   &kp D     &kp F         &kp G                                          &kp H            &kp J   &kp K      &kp L    &kp SEMI  &kp C_PP
 &kp LCTRL  &kp Z   &kp X   &kp C     &kp V         &kp B        &kp LC(LS(N2))     &ter_wsl       &kp N            &kp M   &kp COMMA  &kp DOT  &kp FSLH  &kp DEL
-                           &kp LWIN  &mt LALT ESC  &mo WinCode  &mt LSHFT SPACE    &mt LCTRL RET  &lt WinNav BSPC  &none   &to Mouse
+                           &kp LWIN  &mt LALT ESC  &mo WinCode  &mt LSHFT SPACE    &mt LCTRL RET  &lt WinNav BSPC  &none   &none
             >;
         };
 
@@ -174,7 +153,7 @@
 &kp TAB    &kp Q   &kp W   &kp E     &kp R         &kp T                                          &kp Y            &kp U   &kp I      &kp O    &kp P     &kp LC(TAB)
 &kp LCTRL  &kp A   &kp S   &kp D     &kp F         &kp G                                          &kp H            &kp J   &kp K      &kp L    &kp SEMI  &kp C_PP
 &kp LCTRL  &kp Z   &kp X   &kp C     &kp V         &kp B        &kp LG(SPACE)      &ter_mac       &kp N            &kp M   &kp COMMA  &kp DOT  &kp FSLH  &kp DEL
-                           &kp LALT  &mt LCMD ESC  &mo MacCode  &mt LSHFT SPACE    &mt LCTRL RET  &lt MacNav BSPC  &none   &to Mouse
+                           &kp LALT  &mt LCMD ESC  &mo MacCode  &mt LSHFT SPACE    &mt LCTRL RET  &lt MacNav BSPC  &none   &none
             >;
         };
 
@@ -199,18 +178,6 @@
 &trans  &kp LG(LC(LS(N4)))  &kp CAPS       &kp LC(LG(F))  &kp HOME  &kp PG_UP                          &kp LEFT      &kp DOWN      &kp UP      &kp RIGHT   &kp LC(LEFT)        &kp LC(RIGHT)
 &trans  &ter_mac            &kp LG(SPACE)  &kp LG(M)      &kp END   &kp PG_DN  &to WinDef    &to Game  &kp C_VOL_DN  &kp C_VOL_UP  &kp C_PREV  &kp C_NEXT  &kp LG(LC(LS(N5)))  &none
                                            &trans         &trans    &trans     &trans        &trans    &trans        &trans        &trans
-            >;
-        };
-
-        Mouse_layer {
-            label = "Mouse";
-            display-name = "Mouse";
-            bindings = <
-&none  &none  &none  &none  &none  &none                            &none             &none             &none           &none              &none  &none
-&none  &none  &none  &none  &none  &none                            &msc <SCRL_LEFT>  &msc <SCRL_DOWN>  &msc <SCRL_UP>  &msc <SCRL_RIGHT>  &none  &none
-&none  &none  &none  &none  &none  &none                            &mmv <MOVE_LEFT>  &mmv <MOVE_DOWN>  &mmv <MOVE_UP>  &mmv <MOVE_RIGHT>  &none  &none
-&none  &none  &none  &none  &none  &none  &to MacDef    &to WinDef  &mkp MB2          &none             &none           &none              &none  &none
-                     &none  &none  &none  &none         &mkp MB1    &mkp MB3          &none             &none
             >;
         };
 


### PR DESCRIPTION
- 調整 SVG 影像的高度和 viewBox，以移除版面配置中的滑鼠圖層及相關按鍵
- 從 SVG 鍵盤映射中刪除整個滑鼠圖層群組，包括按鍵和標籤
- 將 Game 與 SYS 圖層定義重新命名至新的圖層索引，調整其位置
- 從鍵盤映射設定中刪除所有與滑鼠相關的行為定義和按鍵綁定
- 完全移除鍵盤映射檔案中的滑鼠圖層按鍵綁定區段

Signed-off-by: Macbook Air <jackie@dast.tw>
