### PR TITLE
修正：更新按鍵映射，使巨集觸發鍵先執行 DOWN，再執行 ENTER

### DIFF
--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -53,7 +53,7 @@
                 <&macro_pause_for_release>,
                 <&macro_tap>,
                 <&kp G &kp H &kp O &kp S &kp T &kp T &kp Y  &kp DOT &kp A &kp P &kp P>,
-                <&macro_tap &kp ENTER>;
+                <&macro_tap &kp DOWN &kp ENTER>;
         };
 
         edge: start_edge {


### PR DESCRIPTION
- 在按鍵映射設定中，將巨集觸發鍵由 ENTER 改為先執行 DOWN，接著執行 ENTER。

Signed-off-by: Macbook Air <jackie@dast.tw>
