### PR TITLE
修正：透過移除 DOWN 鍵按下輸入來簡化宏點擊

### DIFF
--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -53,7 +53,7 @@
                 <&macro_pause_for_release>,
                 <&macro_tap>,
                 <&kp G &kp H &kp O &kp S &kp T &kp T &kp Y  &kp DOT &kp A &kp P &kp P>,
-                <&macro_tap &kp DOWN &kp ENTER>;
+                <&macro_tap &kp ENTER>;
         };
 
         edge: start_edge {


### PR DESCRIPTION
- 從宏點擊中移除 DOWN 鍵按下，僅保留 ENTER 鍵按下。

Signed-off-by: Macbook Air <jackie@dast.tw>
