### PR TITLE
refactor: 簡化按鍵宏以提升程式碼可維護性

### DIFF
--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -52,8 +52,7 @@
                 <&kp LCMD>,
                 <&macro_pause_for_release>,
                 <&macro_tap>,
-                <&kp G &kp H &kp O &kp S &kp T &kp T &kp Y  &kp DOT &kp A &kp P &kp P>,
-                <&macro_tap &kp ENTER>;
+                <&kp G &kp H &kp RET>;
         };
 
         edge: start_edge {


### PR DESCRIPTION
- 透過將長串按鍵序列替換為僅包含三個按鍵的較短序列來簡化宏。

Signed-off-by: Macbook Air <jackie@dast.tw>
