### PR TITLE
feat：新增 terminal_macos 鍵盤巨集的向下鍵按下事件

### DIFF
--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -35,7 +35,7 @@
                 <&kp LWIN>,
                 <&macro_pause_for_release>,
                 <&macro_tap>,
-                <&kp W &kp T &kp RET>;
+                <&kp W &kp T &kp DOWN &kp RET>;
         };
 
         ter_mac: terminal_macos {


### PR DESCRIPTION
- 修改巨集，在 terminal_macos 層的鍵盤映射中於 RETURN 之前增加向下鍵（DOWN）的按下操作

Signed-off-by: Macbook Air <jackie@dast.tw>
