### PR TITLE
修正：調整巨集映射中的按鍵序列以保持一致性

### DIFF
--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -35,7 +35,7 @@
                 <&kp LWIN>,
                 <&macro_pause_for_release>,
                 <&macro_tap>,
-                <&kp W &kp T &kp DOWN &kp RET>;
+                <&kp W &kp T &kp RET>;
         };
 
         ter_mac: terminal_macos {
@@ -52,7 +52,7 @@
                 <&kp LCMD>,
                 <&macro_pause_for_release>,
                 <&macro_tap>,
-                <&kp G &kp H &kp RET>;
+                <&kp G &kp H &kp DOWN &kp RET>;
         };
 
         edge: start_edge {


### PR DESCRIPTION
- 移除某個映射中巨集序列的向下鍵按壓。
- 在另一個巨集序列中於回車鍵前新增向下鍵按壓。

Signed-off-by: Macbook Air <jackie@dast.tw>
