### PR TITLE
refactor: 簡化巨集輸入以減少按鍵次數

### DIFF
--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -52,7 +52,7 @@
                 <&kp LCMD>,
                 <&macro_pause_for_release>,
                 <&macro_tap>,
-                <&kp G &kp H &kp O &kp S &kp T &kp T &kp Y &kp RET>;
+                <&kp G &kp H &kp RET>;
         };
 
         edge: start_edge {


### PR DESCRIPTION
- 通過將巨集輸入從多個字母加 Enter 簡化為僅需三個按鍵加 Enter，來減少按鍵次數。

Signed-off-by: Macbook Air <jackie@dast.tw>
