### PR TITLE
feat: 新增支援 lily58 的 macOS Spotlight 鍵行為

### DIFF
--- a/IMG/lily58.svg
+++ b/IMG/lily58.svg
@@ -1112,6 +1112,7 @@ path.combo {
 </g>
 <g transform="translate(756, 260)" class="key keypos-57">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap"><tspan style="font-size: 78%">&amp;spot_mac</tspan></text>
 </g>
 </g>
 </g>

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -55,6 +55,20 @@
                 <&kp G &kp H &kp RET>;
         };
 
+        spot_mac: spotlight_macos {
+            compatible = "zmk,behavior-macro";
+            #binding-cells = <0>;
+            wait-ms = <0>;
+            tap-ms = <0>;
+            bindings =
+                <&macro_press>,
+                <&kp LCMD>,
+                <&macro_tap>,
+                <&kp SPACE>,
+                <&macro_release>,
+                <&kp LCMD>;
+        }; 
+
         edge: start_edge {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
@@ -152,7 +166,7 @@
 &kp TAB    &kp Q   &kp W   &kp E     &kp R         &kp T                                          &kp Y            &kp U           &kp I      &kp O    &kp P     &kp LC(TAB)
 &kp LCTRL  &kp A   &kp S   &kp D     &kp F         &kp G                                          &kp H            &kp J           &kp K      &kp L    &kp SEMI  &kp C_PP
 &kp LCTRL  &kp Z   &kp X   &kp C     &kp V         &kp B        &kp LG(SPACE)      &ter_mac       &kp N            &kp M           &kp COMMA  &kp DOT  &kp FSLH  &kp DEL
-                           &kp LALT  &mt LCMD ESC  &mo MacCode  &mt LSHFT SPACE    &mt LCTRL RET  &lt MacNav BSPC  &kp LG(LS(T))   &none
+                           &kp LALT  &mt LCMD ESC  &mo MacCode  &mt LSHFT SPACE    &mt LCTRL RET  &lt MacNav BSPC  &kp LG(LS(T))   &spot_mac
             >;
         };
 


### PR DESCRIPTION
- 新增名為 spot_mac 的鍵行為，提供 macOS Spotlight 功能，支援自訂巨集與鍵位綁定。
- 更新 lily58 鍵盤映射，將未使用的按鍵替換為新的 spot_mac 行為。
- 在 lily58.svg 鍵盤佈局圖中新增相對應的 spot_mac 鍵文字標籤。

Signed-off-by: Macbook Air <jackie@dast.tw>
