### PR TITLE
重構：修正按鍵標籤錯誤並重新組織按鍵綁定

### DIFF
--- a/IMG/lily58.svg
+++ b/IMG/lily58.svg
@@ -1048,7 +1048,9 @@ path.combo {
 </g>
 <g transform="translate(560, 182)" class="key keypos-43">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap"><tspan style="font-size: 88%">&amp;ter_mac</tspan></text>
+<text x="0" y="0" class="key tap">
+<tspan x="0" dy="-0.6em">Gui+Sft</tspan><tspan x="0" dy="1.2em">+T</tspan>
+</text>
 </g>
 <g transform="translate(616, 210)" class="key keypos-44">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -1106,13 +1108,11 @@ path.combo {
 </a></g>
 <g transform="translate(700, 260)" class="key keypos-56">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">
-<tspan x="0" dy="-0.6em">Gui+Sft</tspan><tspan x="0" dy="1.2em">+T</tspan>
-</text>
+<text x="0" y="0" class="key tap"><tspan style="font-size: 78%">&amp;spot_mac</tspan></text>
 </g>
 <g transform="translate(756, 260)" class="key keypos-57">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap"><tspan style="font-size: 78%">&amp;spot_mac</tspan></text>
+<text x="0" y="0" class="key tap"><tspan style="font-size: 88%">&amp;ter_mac</tspan></text>
 </g>
 </g>
 </g>

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -162,11 +162,11 @@
             label = "MacDef";
             display-name = "MacOS";
             bindings = <
-&kp ESC    &kp N1  &kp N2  &kp N3    &kp N4        &kp N5                                         &kp N6           &kp N7          &kp N8     &kp N9   &kp N0    &kp MINUS
-&kp TAB    &kp Q   &kp W   &kp E     &kp R         &kp T                                          &kp Y            &kp U           &kp I      &kp O    &kp P     &kp LC(TAB)
-&kp LCTRL  &kp A   &kp S   &kp D     &kp F         &kp G                                          &kp H            &kp J           &kp K      &kp L    &kp SEMI  &kp C_PP
-&kp LCTRL  &kp Z   &kp X   &kp C     &kp V         &kp B        &kp LG(SPACE)      &ter_mac       &kp N            &kp M           &kp COMMA  &kp DOT  &kp FSLH  &kp DEL
-                           &kp LALT  &mt LCMD ESC  &mo MacCode  &mt LSHFT SPACE    &mt LCTRL RET  &lt MacNav BSPC  &kp LG(LS(T))   &spot_mac
+&kp ESC    &kp N1  &kp N2  &kp N3    &kp N4        &kp N5                                         &kp N6           &kp N7    &kp N8     &kp N9   &kp N0    &kp MINUS
+&kp TAB    &kp Q   &kp W   &kp E     &kp R         &kp T                                          &kp Y            &kp U     &kp I      &kp O    &kp P     &kp LC(TAB)
+&kp LCTRL  &kp A   &kp S   &kp D     &kp F         &kp G                                          &kp H            &kp J     &kp K      &kp L    &kp SEMI  &kp C_PP
+&kp LCTRL  &kp Z   &kp X   &kp C     &kp V         &kp B        &kp LG(SPACE)      &kp LG(LS(T))  &kp N            &kp M     &kp COMMA  &kp DOT  &kp FSLH  &kp DEL
+                           &kp LALT  &mt LCMD ESC  &mo MacCode  &mt LSHFT SPACE    &mt LCTRL RET  &lt MacNav BSPC  &spot_mac  &ter_mac
             >;
         };
 


### PR DESCRIPTION
- 交換 SVG 中兩個按鍵的標籤以修正顯示文字。
- 重新排列按鍵映射中的按鍵綁定，以符合更新後的標籤並提升一致性。

Signed-off-by: Macbook Air <jackie@dast.tw>
