### PR TITLE
feat: 修改鍵盤映射層與 SVG 以清晰呈現系統切換功能

### DIFF
--- a/IMG/lily58.svg
+++ b/IMG/lily58.svg
@@ -361,9 +361,15 @@ path.combo {
 </a></g>
 <g transform="translate(700, 260)" class="key keypos-56">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<a href="#System">
+<text x="0" y="0" class="key tap layer-activator">System</text>
+</a><text x="0" y="24" class="key hold">toggle</text>
 </g>
 <g transform="translate(756, 260)" class="key keypos-57">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<a href="#MacOS">
+<text x="0" y="0" class="key tap layer-activator">MacOS</text>
+</a><text x="0" y="24" class="key hold">toggle</text>
 </g>
 </g>
 </g>
@@ -540,17 +546,13 @@ path.combo {
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">_</text>
 </g>
-<g transform="translate(364, 182)" class="key keypos-42">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<a href="#MacOS">
-<text x="0" y="0" class="key tap layer-activator">MacOS</text>
-</a><text x="0" y="24" class="key hold">toggle</text>
+<g transform="translate(364, 182)" class="key trans keypos-42">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
 </g>
-<g transform="translate(560, 182)" class="key keypos-43">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<a href="#Game">
-<text x="0" y="0" class="key tap layer-activator">Game</text>
-</a><text x="0" y="24" class="key hold">toggle</text>
+<g transform="translate(560, 182)" class="key trans keypos-43">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
 </g>
 <g transform="translate(616, 210)" class="key keypos-44">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -601,9 +603,11 @@ path.combo {
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
 <text x="0" y="0" class="key trans tap">▽</text>
 </g>
-<g transform="translate(700, 260)" class="key trans keypos-56">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
-<text x="0" y="0" class="key trans tap">▽</text>
+<g transform="translate(700, 260)" class="key keypos-56">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<a href="#Game">
+<text x="0" y="0" class="key tap layer-activator">Game</text>
+</a><text x="0" y="24" class="key hold">toggle</text>
 </g>
 <g transform="translate(756, 260)" class="key trans keypos-57">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
@@ -794,17 +798,13 @@ path.combo {
 <tspan x="0" dy="-0.6em">PG</tspan><tspan x="0" dy="1.2em">DN</tspan>
 </text>
 </g>
-<g transform="translate(364, 182)" class="key keypos-42">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<a href="#MacOS">
-<text x="0" y="0" class="key tap layer-activator">MacOS</text>
-</a><text x="0" y="24" class="key hold">toggle</text>
+<g transform="translate(364, 182)" class="key trans keypos-42">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
 </g>
-<g transform="translate(560, 182)" class="key keypos-43">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<a href="#Game">
-<text x="0" y="0" class="key tap layer-activator">Game</text>
-</a><text x="0" y="24" class="key hold">toggle</text>
+<g transform="translate(560, 182)" class="key trans keypos-43">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
 </g>
 <g transform="translate(616, 210)" class="key keypos-44">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -1289,17 +1289,13 @@ path.combo {
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
 <text x="0" y="0" class="key tap">_</text>
 </g>
-<g transform="translate(364, 182)" class="key keypos-42">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<a href="#Windows">
-<text x="0" y="0" class="key tap layer-activator">Windows</text>
-</a><text x="0" y="24" class="key hold">toggle</text>
+<g transform="translate(364, 182)" class="key trans keypos-42">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
 </g>
-<g transform="translate(560, 182)" class="key keypos-43">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<a href="#Game">
-<text x="0" y="0" class="key tap layer-activator">Game</text>
-</a><text x="0" y="24" class="key hold">toggle</text>
+<g transform="translate(560, 182)" class="key trans keypos-43">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
 </g>
 <g transform="translate(616, 210)" class="key keypos-44">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -1348,13 +1344,17 @@ path.combo {
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
 <text x="0" y="0" class="key trans tap">▽</text>
 </g>
-<g transform="translate(700, 260)" class="key trans keypos-56">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
-<text x="0" y="0" class="key trans tap">▽</text>
+<g transform="translate(700, 260)" class="key keypos-56">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<a href="#System">
+<text x="0" y="0" class="key tap layer-activator">System</text>
+</a><text x="0" y="24" class="key hold">toggle</text>
 </g>
-<g transform="translate(756, 260)" class="key trans keypos-57">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
-<text x="0" y="0" class="key trans tap">▽</text>
+<g transform="translate(756, 260)" class="key keypos-57">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<a href="#Windows">
+<text x="0" y="0" class="key tap layer-activator">Windows</text>
+</a><text x="0" y="24" class="key hold">toggle</text>
 </g>
 </g>
 </g>
@@ -1543,17 +1543,13 @@ path.combo {
 <tspan x="0" dy="-0.6em">PG</tspan><tspan x="0" dy="1.2em">DN</tspan>
 </text>
 </g>
-<g transform="translate(364, 182)" class="key keypos-42">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<a href="#Windows">
-<text x="0" y="0" class="key tap layer-activator">Windows</text>
-</a><text x="0" y="24" class="key hold">toggle</text>
+<g transform="translate(364, 182)" class="key trans keypos-42">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
 </g>
-<g transform="translate(560, 182)" class="key keypos-43">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<a href="#Game">
-<text x="0" y="0" class="key tap layer-activator">Game</text>
-</a><text x="0" y="24" class="key hold">toggle</text>
+<g transform="translate(560, 182)" class="key trans keypos-43">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
 </g>
 <g transform="translate(616, 210)" class="key keypos-44">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -1727,6 +1723,9 @@ path.combo {
 </g>
 <g transform="translate(616, 154)" class="key keypos-30">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<a href="#System">
+<text x="0" y="0" class="key tap layer-activator">System</text>
+</a><text x="0" y="24" class="key hold">toggle</text>
 </g>
 <g transform="translate(672, 147)" class="key keypos-31">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -1779,9 +1778,6 @@ path.combo {
 </g>
 <g transform="translate(560, 182)" class="key keypos-43">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<a href="#Windows">
-<text x="0" y="0" class="key tap layer-activator">Windows</text>
-</a><text x="0" y="24" class="key hold">toggle</text>
 </g>
 <g transform="translate(616, 210)" class="key keypos-44">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -1819,9 +1815,6 @@ path.combo {
 </g>
 <g transform="translate(574, 266) rotate(-30.0)" class="key keypos-54">
 <rect rx="6" ry="6" x="-26" y="-40" width="52" height="80" class="key"/>
-<a href="#System">
-<text x="0" y="0" class="key tap layer-activator">System</text>
-</a><text x="0" y="38" class="key hold">toggle</text>
 </g>
 <g transform="translate(644, 266)" class="key keypos-55">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -1959,6 +1952,9 @@ path.combo {
 </g>
 <g transform="translate(784, 147)" class="key keypos-33">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<a href="#Game">
+<text x="0" y="0" class="key tap layer-activator">Game</text>
+</a><text x="0" y="24" class="key hold">toggle</text>
 </g>
 <g transform="translate(840, 161)" class="key keypos-34">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -1990,9 +1986,7 @@ path.combo {
 </g>
 <g transform="translate(560, 182)" class="key keypos-43">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<a href="#Game">
-<text x="0" y="0" class="key tap layer-activator">Game</text>
-</a><text x="0" y="24" class="key hold">toggle</text>
+<text x="0" y="0" class="key tap">&amp;noen</text>
 </g>
 <g transform="translate(616, 210)" class="key keypos-44">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -126,11 +126,11 @@
             label = "WinDef";
             display-name = "Windows";
             bindings = <
-&kp ESC    &kp N1  &kp N2  &kp N3    &kp N4        &kp N5                                         &kp N6           &kp N7  &kp N8     &kp N9   &kp N0    &kp MINUS
-&kp TAB    &kp Q   &kp W   &kp E     &kp R         &kp T                                          &kp Y            &kp U   &kp I      &kp O    &kp P     &kp LC(TAB)
-&kp LCTRL  &kp A   &kp S   &kp D     &kp F         &kp G                                          &kp H            &kp J   &kp K      &kp L    &kp SEMI  &kp C_PP
-&kp LCTRL  &kp Z   &kp X   &kp C     &kp V         &kp B        &kp LC(LS(N2))     &ter_wsl       &kp N            &kp M   &kp COMMA  &kp DOT  &kp FSLH  &kp DEL
-                           &kp LWIN  &mt LALT ESC  &mo WinCode  &mt LSHFT SPACE    &mt LCTRL RET  &lt WinNav BSPC  &none   &none
+&kp ESC    &kp N1  &kp N2  &kp N3    &kp N4        &kp N5                                         &kp N6           &kp N7   &kp N8     &kp N9   &kp N0    &kp MINUS
+&kp TAB    &kp Q   &kp W   &kp E     &kp R         &kp T                                          &kp Y            &kp U    &kp I      &kp O    &kp P     &kp LC(TAB)
+&kp LCTRL  &kp A   &kp S   &kp D     &kp F         &kp G                                          &kp H            &kp J    &kp K      &kp L    &kp SEMI  &kp C_PP
+&kp LCTRL  &kp Z   &kp X   &kp C     &kp V         &kp B        &kp LC(LS(N2))     &ter_wsl       &kp N            &kp M    &kp COMMA  &kp DOT  &kp FSLH  &kp DEL
+                           &kp LWIN  &mt LALT ESC  &mo WinCode  &mt LSHFT SPACE    &mt LCTRL RET  &lt WinNav BSPC  &to SYS  &to MacDef
             >;
         };
 
@@ -138,11 +138,11 @@
             label = "WinCode";
             display-name = "WinCode";
             bindings = <
-&trans  &kp F1    &kp F2  &kp F3     &kp F4     &kp F5                             &kp F6     &kp F7    &kp F8    &kp F9    &kp F10     &kp F11
-&trans  &kp EXCL  &kp AT  &kp HASH   &kp DLLR   &kp PRCNT                          &kp CARET  &kp AMPS  &kp STAR  &kp LPAR  &kp RPAR    &kp F12
-&trans  &list     &col    &kp GRAVE  &kp MINUS  &kp EQUAL                          &kp LBRC   &kp RBRC  &kp SQT   &kp DQT   &kp LA(F4)  &kp LC(LG(D))
-&trans  &tabs     &row    &kp TILDE  &kp PLUS   &kp UNDER  &to MacDef    &to Game  &kp LBKT   &kp RBKT  &kp PIPE  &kp BSLH  &kp DEL     &kp LC(LG(F4))
-                          &trans     &trans     &trans     &trans        &trans    &trans     &trans    &trans
+&trans  &kp F1    &kp F2  &kp F3     &kp F4     &kp F5                       &kp F6     &kp F7    &kp F8    &kp F9    &kp F10     &kp F11
+&trans  &kp EXCL  &kp AT  &kp HASH   &kp DLLR   &kp PRCNT                    &kp CARET  &kp AMPS  &kp STAR  &kp LPAR  &kp RPAR    &kp F12
+&trans  &list     &col    &kp GRAVE  &kp MINUS  &kp EQUAL                    &kp LBRC   &kp RBRC  &kp SQT   &kp DQT   &kp LA(F4)  &kp LC(LG(D))
+&trans  &tabs     &row    &kp TILDE  &kp PLUS   &kp UNDER  &trans    &trans  &kp LBKT   &kp RBKT  &kp PIPE  &kp BSLH  &kp DEL     &kp LC(LG(F4))
+                          &trans     &trans     &trans     &trans    &trans  &trans     &to Game  &trans
             >;
         };
 
@@ -150,11 +150,11 @@
             label = "WinNAV";
             display-name = "WinNAV";
             bindings = <
-&trans  &kp F1         &kp F2    &kp F3        &kp F4    &kp F5                             &kp F6        &kp F7        &kp F8      &kp F9      &kp F10           &kp F11
-&trans  &kp N1         &kp N2    &kp N3        &kp N4    &kp N5                             &kp N6        &kp N7        &kp N8      &kp N9      &kp N0            &kp F12
-&trans  &kp LG(LS(S))  &kp CAPS  &kp LG(UP)    &kp HOME  &kp PG_UP                          &kp LEFT      &kp DOWN      &kp UP      &kp RIGHT   &kp LC(LG(LEFT))  &kp LC(LG(RIGHT))
-&trans  &ter_wsl       &edge     &kp LG(DOWN)  &kp END   &kp PG_DN  &to MacDef    &to Game  &kp C_VOL_DN  &kp C_VOL_UP  &kp C_PREV  &kp C_NEXT  &kp LC(LA(DEL))   &kp DEL
-                                 &trans        &trans    &trans     &trans        &trans    &trans        &trans        &trans
+&trans  &kp F1         &kp F2    &kp F3        &kp F4    &kp F5                       &kp F6        &kp F7        &kp F8      &kp F9      &kp F10           &kp F11
+&trans  &kp N1         &kp N2    &kp N3        &kp N4    &kp N5                       &kp N6        &kp N7        &kp N8      &kp N9      &kp N0            &kp F12
+&trans  &kp LG(LS(S))  &kp CAPS  &kp LG(UP)    &kp HOME  &kp PG_UP                    &kp LEFT      &kp DOWN      &kp UP      &kp RIGHT   &kp LC(LG(LEFT))  &kp LC(LG(RIGHT))
+&trans  &ter_wsl       &edge     &kp LG(DOWN)  &kp END   &kp PG_DN  &trans    &trans  &kp C_VOL_DN  &kp C_VOL_UP  &kp C_PREV  &kp C_NEXT  &kp LC(LA(DEL))   &kp DEL
+                                 &trans        &trans    &trans     &trans    &trans  &trans        &trans        &trans
             >;
         };
 
@@ -174,11 +174,11 @@
             label = "MacCode";
             display-name = "MacCode";
             bindings = <
-&trans  &kp F1    &kp F2  &kp F3     &kp F4     &kp F5                             &kp F6     &kp F7    &kp F8    &kp F9    &kp F10      &kp F11
-&trans  &kp EXCL  &kp AT  &kp HASH   &kp DLLR   &kp PRCNT                          &kp CARET  &kp AMPS  &kp STAR  &kp LPAR  &kp RPAR     &kp F12
-&trans  &list     &col    &kp GRAVE  &kp MINUS  &kp EQUAL                          &kp LBRC   &kp RBRC  &kp SQT   &kp DQT   &kp LC(TAB)  &kp LG(LC(F))
-&trans  &tabs     &row    &kp TILDE  &kp PLUS   &kp UNDER  &to WinDef    &to Game  &kp LBKT   &kp RBKT  &kp PIPE  &kp BSLH  &kp DEL      &kp LG(RET)
-                          &trans     &trans     &trans     &trans        &trans    &trans     &trans    &trans
+&trans  &kp F1    &kp F2  &kp F3     &kp F4     &kp F5                       &kp F6     &kp F7    &kp F8    &kp F9    &kp F10      &kp F11
+&trans  &kp EXCL  &kp AT  &kp HASH   &kp DLLR   &kp PRCNT                    &kp CARET  &kp AMPS  &kp STAR  &kp LPAR  &kp RPAR     &kp F12
+&trans  &list     &col    &kp GRAVE  &kp MINUS  &kp EQUAL                    &kp LBRC   &kp RBRC  &kp SQT   &kp DQT   &kp LC(TAB)  &kp LG(LC(F))
+&trans  &tabs     &row    &kp TILDE  &kp PLUS   &kp UNDER  &trans    &trans  &kp LBKT   &kp RBKT  &kp PIPE  &kp BSLH  &kp DEL      &kp LG(RET)
+                          &trans     &trans     &trans     &trans    &trans  &trans     &to SYS   &to WinDef
             >;
         };
 
@@ -186,11 +186,11 @@
             label = "MacNav";
             display-name = "MacNAV";
             bindings = <
-&trans  &kp F1              &kp F2         &kp F3         &kp F4    &kp F5                             &kp F6        &kp F7        &kp F8      &kp F9      &kp F10             &kp F11
-&trans  &kp N1              &kp N2         &kp N3         &kp N4    &kp N5                             &kp N6        &kp N7        &kp N8      &kp N9      &kp N0              &kp F12
-&trans  &kp LG(LC(LS(N4)))  &kp CAPS       &kp LC(LG(F))  &kp HOME  &kp PG_UP                          &kp LEFT      &kp DOWN      &kp UP      &kp RIGHT   &kp LC(LEFT)        &kp LC(RIGHT)
-&trans  &ter_mac            &kp LG(SPACE)  &kp LG(M)      &kp END   &kp PG_DN  &to WinDef    &to Game  &kp C_VOL_DN  &kp C_VOL_UP  &kp C_PREV  &kp C_NEXT  &kp LG(LC(LS(N5)))  &none
-                                           &trans         &trans    &trans     &trans        &trans    &trans        &trans        &trans
+&trans  &kp F1              &kp F2         &kp F3         &kp F4    &kp F5                       &kp F6        &kp F7        &kp F8      &kp F9      &kp F10             &kp F11
+&trans  &kp N1              &kp N2         &kp N3         &kp N4    &kp N5                       &kp N6        &kp N7        &kp N8      &kp N9      &kp N0              &kp F12
+&trans  &kp LG(LC(LS(N4)))  &kp CAPS       &kp LC(LG(F))  &kp HOME  &kp PG_UP                    &kp LEFT      &kp DOWN      &kp UP      &kp RIGHT   &kp LC(LEFT)        &kp LC(RIGHT)
+&trans  &ter_mac            &kp LG(SPACE)  &kp LG(M)      &kp END   &kp PG_DN  &trans    &trans  &kp C_VOL_DN  &kp C_VOL_UP  &kp C_PREV  &kp C_NEXT  &kp LG(LC(LS(N5)))  &none
+                                           &trans         &trans    &trans     &trans    &trans  &trans        &trans        &trans
             >;
         };
 
@@ -198,11 +198,11 @@
             label = "Game";
             display-name = "Game";
             bindings = <
-&kp ESC    &kp N1     &kp N2  &kp N3   &kp N4  &kp N5                           &none  &none       &none       &none  &none  &none
-&none      &kp Q      &none   &kp W    &kp E   &kp R                            &none  &none       &none       &none  &none  &none
-&kp LCTRL  &kp LSHFT  &kp A   &kp S    &kp D   &none                            &none  &to WinDef  &to MacDef  &none  &none  &none
-&kp G      &kp N6     &kp N7  &kp N8   &kp N9  &kp N0  &kp B        &to WinDef  &none  &none       &none       &none  &none  &none
-                              &kp TAB  &kp M   &kp Z   &kp SPACE    &to SYS     &none  &none       &none
+&kp ESC    &kp N1     &kp N2  &kp N3   &kp N4  &kp N5                      &none    &none       &none       &none  &none  &none
+&none      &kp Q      &none   &kp W    &kp E   &kp R                       &none    &none       &none       &none  &none  &none
+&kp LCTRL  &kp LSHFT  &kp A   &kp S    &kp D   &none                       &to SYS  &to WinDef  &to MacDef  &none  &none  &none
+&kp G      &kp N6     &kp N7  &kp N8   &kp N9  &kp N0  &kp B        &none  &none    &none       &none       &none  &none  &none
+                              &kp TAB  &kp M   &kp Z   &kp SPACE    &none  &none    &none       &none
             >;
         };
 
@@ -210,11 +210,11 @@
             label = "SYS";
             display-name = "System";
             bindings = <
-&none  &none  &none  &none  &none  &bt BT_CLR                      &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4  &none
-&none  &none  &none  &none  &none  &none                           &none         &none         &none         &none         &none         &none
-&none  &none  &none  &none  &none  &bootloader                     &bootloader   &to WinDef    &to MacDef    &none         &none         &none
-&none  &none  &none  &none  &none  &sys_reset   &none    &to Game  &sys_reset    &none         &none         &none         &none         &none
-                     &none  &none  &none        &none    &none     &none         &none         &none
+&none  &none  &none  &none  &none  &bt BT_CLR                   &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4  &none
+&none  &none  &none  &none  &none  &none                        &none         &none         &none         &none         &none         &none
+&none  &none  &none  &none  &none  &bootloader                  &bootloader   &to WinDef    &to MacDef    &to Game      &none         &none
+&none  &none  &none  &none  &none  &sys_reset   &none    &noen  &sys_reset    &none         &none         &none         &none         &none
+                     &none  &none  &none        &none    &none  &none         &none         &none
             >;
         };
     };


### PR DESCRIPTION
- 在 lily58 的 SVG 中，將部分靜態鍵位 SVG 元素替換為半透明版本，顯示向下箭頭符號，取代原本的層級啟用連結。
- 在 SVG 指定位置新增可點擊按鍵，標示為 System、MacOS 和 Windows，並附加切換保持文字與連結。
- 更新 SVG 中多組鍵位的外觀，並為其加入超連結包覆，指向不同的層級或系統。
- 修改鍵盤映射設定，將部分直接層級切換改為半透明鍵或在多層間的過渡鍵。
- 調整鍵盤映射綁定，以更清楚區分 System、MacOS、Windows 及 Game 佈局間的系統層級與切換行為。
- 從 Game 層的鍵盤映射中移除部分層級啟用連結，並以半透明鍵或無操作條目替換。
- 新增或修改 bootloader 及重置鍵位指派，使 System 層設定中包含 Game 層的過渡功能。

Signed-off-by: Macbook Air <jackie@dast.tw>
