### PR TITLE
docs: 新增 ZMK Studio 整合的完整建置與設定說明

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,17 @@ west build -p=auto -d build/left  -b nice_nano_v2 -- -DSHIELD=lily58_left
 west build -p=auto -d build/right -b nice_nano_v2 -- -DSHIELD=lily58_right
 ```
 
+含 Nice!View 與 ZMK Studio（與 `build.yaml` 一致）：
+
+```bash
+west build -p=auto -d build/left  -b nice_nano_v2 -- \
+  -DSHIELD="lily58_left nice_view_adapter nice_view" \
+  -DSNIPPET=studio-rpc-usb-uart
+
+west build -p=auto -d build/right -b nice_nano_v2 -- \
+  -DSHIELD="lily58_right nice_view_adapter nice_view"
+```
+
 ## 程式風格與命名規範
 
 - 縮排：YAML 2 空白；`.keymap`/`.conf` 以 2 空白對齊區塊。
@@ -63,6 +74,7 @@ west build -p=auto -d build/right -b nice_nano_v2 -- -DSHIELD=lily58_right
 
 - 請勿提交產物與私密資料（`build/`、`.uf2`、序號/金鑰）。
 - 變更 `west.yml` 或 `build.yaml` 前，確認 CI 矩陣仍涵蓋左右半部與顯示模組。
+- Studio Snippet 僅需在左半部啟用（USB-UART），與現行 `build.yaml` 一致。
 
 ## 代理（AI 助理）補充
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 - 多層鍵盤映射：支援 Windows / macOS / 遊戲等層。
 - 無線配置：支援 Nice!Nano V2 與 Nice!View 顯示模組。
 - 省電：深度睡眠，預設 30 分鐘後進入。
+- ZMK Studio：支援即時 Keymap 更新（左側以 USB-UART Snippet）。
 - CI 自動化：GitHub Actions 產出左右半部韌體。
 
 ## 建置與使用
@@ -25,16 +26,35 @@ west init -l config
 west update
 ```
 
-2) 本機建置左右半部（輸出位於 `build/<side>/zephyr/zmk.uf2`）：
+2) 本機建置左右半部（輸出位於 `build/<side>/zephyr/zmk.uf2`）
+
+基本（不含顯示模組）：
 
 ```bash
 west build -d build/left  -b nice_nano_v2 -- -DSHIELD=lily58_left
 west build -d build/right -b nice_nano_v2 -- -DSHIELD=lily58_right
 ```
 
+含 Nice!View 與 ZMK Studio（與 `build.yaml` 一致）：
+
+```bash
+west build -p=auto -d build/left  -b nice_nano_v2 -- \
+  -DSHIELD="lily58_left nice_view_adapter nice_view" \
+  -DSNIPPET=studio-rpc-usb-uart
+
+west build -p=auto -d build/right -b nice_nano_v2 -- \
+  -DSHIELD="lily58_right nice_view_adapter nice_view"
+```
+
 3) 將產生之 `zmk.uf2` 分別燒錄到左右半部的 Nice!Nano V2。
 
 4) 依需求調整 `config/lily58.keymap` 與 `config/lily58.conf`，重新建置驗證。
+
+## ZMK Studio（可選）
+
+- 設定已於 `config/lily58.conf:19` 啟用 `CONFIG_ZMK_STUDIO=y` 並解鎖。
+- 左半部建置時加入 `-DSNIPPET=studio-rpc-usb-uart`，以 USB 連線使用 Studio。
+- 右半部通常不需要加入該 Snippet（CI 亦僅在左側啟用）。
 
 ## 測試與 CI
 
@@ -43,10 +63,16 @@ west build -d build/right -b nice_nano_v2 -- -DSHIELD=lily58_right
 - CI 會依 `build.yaml` 定義的矩陣建置左右半部與顯示模組。
 - 請勿提交產物與私密資料（`build/`、`.uf2`、序號/金鑰）。
 
+## 藍牙與系統層
+
+- 於 `SYS` 層可清除配對與選擇插槽：`bt BT_CLR`、`bt BT_SEL 0..4`。
+- 進入 Bootloader 與系統重啟：`bootloader`、`sys_reset`。
+- 相關配置可參考 `config/lily58.keymap` 的 `SYS_layer`。
+
 ## AGENTS 指南摘要
 
 - 結構與資產：`config/` 放置主要設定；`IMG/` 放置圖片；建置矩陣由 `build.yaml` 管理。
-- 建置指令：初始化 `west init -l config && west update`；左右半部分別以 `west build -d build/<side> -b nice_nano_v2 -- -DSHIELD=lily58_<side>` 建置；常用 `-p=auto` 進行乾淨重建。
+- 建置指令：初始化 `west init -l config && west update`；左右半部分別以 `west build -d build/<side> -b nice_nano_v2 -- -DSHIELD=lily58_<side>` 建置；含顯示模組與 Studio 參見上方指令；常用 `-p=auto` 進行乾淨重建。
 - 風格規範：YAML 與 `.keymap`/`.conf` 皆採 2 空白縮排；層名稱全大寫（如 `BASE`、`NAV`）；`.conf` 僅使用既有 `CONFIG_` 開關。
 - 測試要求：左右半部皆需成功建置產生 `zmk.uf2`；重大變更提供新舊層級對照或 keymap 差異。
 - 提交規範：建議使用 Conventional Commits；PR 需附變更摘要、影響層級、截圖/`IMG/` 圖片（如有）、本機建置結果與重現指令。


### PR DESCRIPTION
- 新增 Nice!View 與 ZMK Studio 整合的建置說明，包括在左側鍵盤使用 USB-UART 程式碼片段。
- 明確說明 Studio 程式碼片段僅需應用於左側鍵盤，與目前 build.yaml 設定一致。
- 更新 README，加入 ZMK Studio 的設定與使用細節，並附範例建置指令。
- 新增藍牙與系統層級指令的資訊。
- 精進建置與風格指南，加入新功能說明及關於搭配顯示模組與 Studio 建置的澄清。

Signed-off-by: Macbook Air <jackie@dast.tw>
