### PR TITLE
dev

### DIFF
--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -52,7 +52,7 @@
                 <&kp LCMD>,
                 <&macro_pause_for_release>,
                 <&macro_tap>,
-                <&kp G &kp H &kp O &kp S &kp T &kp T &kp Y &kp RET>;
+                <&kp LS(G) &kp H &kp O &kp S &kp T &kp T &kp Y &kp RET>;
         };
 
         spot_mac: spotlight_macos {

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -52,7 +52,7 @@
                 <&kp LCMD>,
                 <&macro_pause_for_release>,
                 <&macro_tap>,
-                <&kp G &kp h &kp o &kp s &kp t &kp t &kp y &kp RET>;
+                <&kp G &kp H &kp O &kp S &kp T &kp T &kp Y &kp RET>;
         };
 
         spot_mac: spotlight_macos {


### PR DESCRIPTION
- **修正：在 Lily58 鍵盤配置巨集序列中使用大寫字母**
- **修正：在巨集按鍵序列中將單純的 'G' 替換為 Shift+G**
