### PR TITLE
feat: 優化鍵盤層切換並更新 SVG 層標籤

### DIFF
--- a/IMG/lily58.svg
+++ b/IMG/lily58.svg
@@ -1934,21 +1934,12 @@ path.combo {
 </g>
 <g transform="translate(672, 147)" class="key keypos-31">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<a href="#Windows">
-<text x="0" y="0" class="key tap layer-activator">Windows</text>
-</a><text x="0" y="24" class="key hold">toggle</text>
 </g>
 <g transform="translate(728, 140)" class="key keypos-32">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<a href="#MacOS">
-<text x="0" y="0" class="key tap layer-activator">MacOS</text>
-</a><text x="0" y="24" class="key hold">toggle</text>
 </g>
 <g transform="translate(784, 147)" class="key keypos-33">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<a href="#Game">
-<text x="0" y="0" class="key tap layer-activator">Game</text>
-</a><text x="0" y="24" class="key hold">toggle</text>
 </g>
 <g transform="translate(840, 161)" class="key keypos-34">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -2017,12 +2008,21 @@ path.combo {
 </g>
 <g transform="translate(644, 266)" class="key keypos-55">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<a href="#Game">
+<text x="0" y="0" class="key tap layer-activator">Game</text>
+</a><text x="0" y="24" class="key hold">toggle</text>
 </g>
 <g transform="translate(700, 260)" class="key keypos-56">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<a href="#MacOS">
+<text x="0" y="0" class="key tap layer-activator">MacOS</text>
+</a><text x="0" y="24" class="key hold">toggle</text>
 </g>
 <g transform="translate(756, 260)" class="key keypos-57">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<a href="#Windows">
+<text x="0" y="0" class="key tap layer-activator">Windows</text>
+</a><text x="0" y="24" class="key hold">toggle</text>
 </g>
 </g>
 </g>

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -212,9 +212,9 @@
             bindings = <
 &none  &none  &none  &none  &none  &bt BT_CLR                   &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4  &none
 &none  &none  &none  &none  &none  &none                        &none         &none         &none         &none         &none         &none
-&none  &none  &none  &none  &none  &bootloader                  &bootloader   &to WinDef    &to MacDef    &to Game      &none         &none
+&none  &none  &none  &none  &none  &bootloader                  &bootloader   &none         &none         &none         &none         &none
 &none  &none  &none  &none  &none  &sys_reset   &none    &none  &sys_reset    &none         &none         &none         &none         &none
-                     &none  &none  &none        &none    &none  &none         &none         &none
+                     &none  &none  &none        &none    &none  &to Game      &to MacDef    &to WinDef
             >;
         };
     };


### PR DESCRIPTION
- 移除 SVG 檔案中上方鍵位位置的 Windows、MacOS 及 Game 層的可點擊文字標籤。
- 在 SVG 檔案中下方鍵位位置新增 Game、MacOS 及 Windows 層的可點擊文字標籤。
- 透過將層切換綁定替換為無操作命令，禁用鍵盤映射中特定鍵的層切換功能。
- 通過新增切換至 Game、MacOS 及 Windows 層的綁定，啟用鍵盤映射中其他鍵的層切換功能。

Signed-off-by: Macbook Air <jackie@dast.tw>
