### PR TITLE
重構：重構 SVG 及鍵盤映射以重新整理系統與 MacOS 鍵

### DIFF
--- a/IMG/lily58.svg
+++ b/IMG/lily58.svg
@@ -1717,21 +1717,12 @@ path.combo {
 </g>
 <g transform="translate(616, 154)" class="key keypos-30">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<a href="#System">
-<text x="0" y="0" class="key tap layer-activator">System</text>
-</a><text x="0" y="24" class="key hold">toggle</text>
 </g>
 <g transform="translate(672, 147)" class="key keypos-31">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<a href="#Windows">
-<text x="0" y="0" class="key tap layer-activator">Windows</text>
-</a><text x="0" y="24" class="key hold">toggle</text>
 </g>
 <g transform="translate(728, 140)" class="key keypos-32">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<a href="#MacOS">
-<text x="0" y="0" class="key tap layer-activator">MacOS</text>
-</a><text x="0" y="24" class="key hold">toggle</text>
 </g>
 <g transform="translate(784, 147)" class="key keypos-33">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -1812,12 +1803,21 @@ path.combo {
 </g>
 <g transform="translate(644, 266)" class="key keypos-55">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<a href="#System">
+<text x="0" y="0" class="key tap layer-activator">System</text>
+</a><text x="0" y="24" class="key hold">toggle</text>
 </g>
 <g transform="translate(700, 260)" class="key keypos-56">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<a href="#MacOS">
+<text x="0" y="0" class="key tap layer-activator">MacOS</text>
+</a><text x="0" y="24" class="key hold">toggle</text>
 </g>
 <g transform="translate(756, 260)" class="key keypos-57">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<a href="#MacOS">
+<text x="0" y="0" class="key tap layer-activator">MacOS</text>
+</a><text x="0" y="24" class="key hold">toggle</text>
 </g>
 </g>
 </g>

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -200,9 +200,9 @@
             bindings = <
 &kp ESC    &kp N1     &kp N2  &kp N3   &kp N4  &kp N5                      &none    &none       &none       &none  &none  &none
 &none      &kp Q      &none   &kp W    &kp E   &kp R                       &none    &none       &none       &none  &none  &none
-&kp LCTRL  &kp LSHFT  &kp A   &kp S    &kp D   &none                       &to SYS  &to WinDef  &to MacDef  &none  &none  &none
+&kp LCTRL  &kp LSHFT  &kp A   &kp S    &kp D   &none                       &none    &none       &none       &none  &none  &none
 &kp G      &kp N6     &kp N7  &kp N8   &kp N9  &kp N0  &kp B        &none  &none    &none       &none       &none  &none  &none
-                              &kp TAB  &kp M   &kp Z   &kp SPACE    &none  &none    &none       &none
+                              &kp TAB  &kp M   &kp Z   &kp SPACE    &none  &to SYS  &to MacDef  &to MacDef
             >;
         };
 


### PR DESCRIPTION
- 移除 SVG 檔案初始位置中與系統、Windows 及 MacOS 鍵相關的連結與標籤。
- 在 SVG 檔案不同位置新增帶有切換標籤的系統與 MacOS 鍵連結。
- 從鍵盤映射中移除 SYS、WinDef 及 MacDef 層的啟用鍵綁定。
- 在鍵盤映射布局末端新增或修改 SYS 與 MacDef 層的鍵綁定。

Signed-off-by: Macbook Air <jackie@dast.tw>
