### PR TITLE
feat: 更新鍵盤佈局及預設 Windows 快鍵配置

### DIFF
--- a/IMG/lily58.svg
+++ b/IMG/lily58.svg
@@ -1815,8 +1815,8 @@ path.combo {
 </g>
 <g transform="translate(756, 260)" class="key keypos-57">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<a href="#MacOS">
-<text x="0" y="0" class="key tap layer-activator">MacOS</text>
+<a href="#Windows">
+<text x="0" y="0" class="key tap layer-activator">Windows</text>
 </a><text x="0" y="24" class="key hold">toggle</text>
 </g>
 </g>

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -202,7 +202,7 @@
 &none      &kp Q      &none   &kp W    &kp E   &kp R                       &none    &none       &none       &none  &none  &none
 &kp LCTRL  &kp LSHFT  &kp A   &kp S    &kp D   &none                       &none    &none       &none       &none  &none  &none
 &kp G      &kp N6     &kp N7  &kp N8   &kp N9  &kp N0  &kp B        &none  &none    &none       &none       &none  &none  &none
-                              &kp TAB  &kp M   &kp Z   &kp SPACE    &none  &to SYS  &to MacDef  &to MacDef
+                              &kp TAB  &kp M   &kp Z   &kp SPACE    &none  &to SYS  &to MacDef  &to WinDef
             >;
         };
 


### PR DESCRIPTION
- 更新鍵盤 SVG，將 MacOS 層啟動標籤替換為 Windows
- 更改鍵盤映射，將預設層參考從 MacDef 切換為 WinDef

Signed-off-by: Macbook Air <jackie@dast.tw>
