### PR TITLE
重構：改進按鍵巨集的時序與清晰度

### DIFF
--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -52,7 +52,9 @@
                 <&kp LCMD>,
                 <&macro_pause_for_release>,
                 <&macro_tap>,
-                <&kp LS(G) &kp H &kp O &kp S &kp T &kp T &kp Y &kp RET>;
+                <&kp LS(G) &kp H &kp O &kp S &kp T &kp T &kp Y>,
+                <&macro_wait_time 500>,
+                <&kp RET>;
         };
 
         spot_mac: spotlight_macos {


### PR DESCRIPTION
- 將長按鍵巨集拆分為獨立的按鍵和等待指令，以提升清晰度與時序
- 在巨集序列中新增發送返回鍵前的 500 毫秒延遲

Signed-off-by: Macbook Air <jackie@dast.tw>
