### PR TITLE
feat: 強化鍵盤 SVG 與鍵位圖，新增 Mac 與系統圖層

### DIFF
--- a/IMG/lily58.svg
+++ b/IMG/lily58.svg
@@ -1790,12 +1790,21 @@ path.combo {
 </g>
 <g transform="translate(224, 260)" class="key keypos-51">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<a href="#MacOS">
+<text x="0" y="0" class="key tap layer-activator">MacOS</text>
+</a><text x="0" y="24" class="key hold">toggle</text>
 </g>
 <g transform="translate(280, 266)" class="key keypos-52">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<a href="#System">
+<text x="0" y="0" class="key tap layer-activator">System</text>
+</a><text x="0" y="24" class="key hold">toggle</text>
 </g>
 <g transform="translate(350, 266) rotate(30.0)" class="key keypos-53">
 <rect rx="6" ry="6" x="-26" y="-40" width="52" height="80" class="key"/>
+<a href="#Windows">
+<text x="0" y="0" class="key tap layer-activator">Windows</text>
+</a><text x="0" y="38" class="key hold">toggle</text>
 </g>
 <g transform="translate(574, 266) rotate(-30.0)" class="key keypos-54">
 <rect rx="6" ry="6" x="-26" y="-40" width="52" height="80" class="key"/>
@@ -1817,9 +1826,6 @@ path.combo {
 </g>
 <g transform="translate(756, 260)" class="key keypos-57">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<a href="#Windows">
-<text x="0" y="0" class="key tap layer-activator">Windows</text>
-</a><text x="0" y="24" class="key hold">toggle</text>
 </g>
 </g>
 </g>

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -207,11 +207,11 @@
             label = "Mouse";
             display-name = "Mouse";
             bindings = <
-&kp ESC  &none  &none  &none  &none  &none                      &none           &none           &none         &none            &none  &none
-&none    &none  &none  &none  &none  &none                      &none           &none           &none         &none            &none  &none
-&none    &none  &none  &none  &none  &none                      &mmv MOVE_LEFT  &mmv MOVE_DOWN  &mmv MOVE_UP  &mmv MOVE_RIGHT  &none  &none
-&none    &none  &none  &none  &none  &none  &none    &none      &none           &msc SCRL_DOWN  &msc SCRL_UP  &none            &none  &none
-                       &none  &none  &none  &none    &mkp LCLK  &mkp RCLK       &mkp MCLK       &to WinDef
+&kp ESC  &none  &none  &none  &none       &none                             &none           &none           &none         &none            &none  &none
+&none    &none  &none  &none  &none       &none                             &none           &none           &none         &none            &none  &none
+&none    &none  &none  &none  &none       &none                             &mmv MOVE_LEFT  &mmv MOVE_DOWN  &mmv MOVE_UP  &mmv MOVE_RIGHT  &none  &none
+&none    &none  &none  &none  &none       &none    &none         &none      &none           &msc SCRL_DOWN  &msc SCRL_UP  &none            &none  &none
+                       &none  &to MacDef  &to SYS  &to WinDef    &mkp LCLK  &mkp RCLK       &mkp MCLK       &none
             >;
         };
 


### PR DESCRIPTION
- 在鍵盤 SVG 圖像中新增可點擊的文字標籤，包含指向 MacOS、系統及 Windows 圖層的連結，取代先前僅有的 Windows 標籤。
- 更新鍵位圖設定，新增 MacDef 與 SYS 圖層的圖層切換綁定，與 WinDef 同時支援。

Signed-off-by: WSL <jackie@dast.tw>
