### PR TITLE
refactor: 改善按鍵處理，將組合鍵分離並重新格式化

### DIFF
--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -42,7 +42,7 @@
                 <&kp LWIN>,
                 <&macro_pause_for_release>,
                 <&macro_tap>,
-                <&kp W &kp T &kp RET>;
+                <&kp W>, <&kp T>, <&kp RET>;
         };
 
         ter_mac: terminal_macos {
@@ -59,9 +59,7 @@
                 <&kp LCMD>,
                 <&macro_pause_for_release>,
                 <&macro_tap>,
-                <&kp LS(G) &kp H &kp O &kp S &kp T &kp T &kp Y>,
-                <&macro_wait_time 500>,
-                <&kp RET>;
+                <&kp G>, <&kp H>, <&kp O>, <&kp S>, <&kp T>, <&kp T>, <&kp Y>, <&kp RET>;
         };
 
         spot_mac: spotlight_macos {
@@ -92,7 +90,7 @@
                 <&kp LWIN>,
                 <&macro_pause_for_release>,
                 <&macro_tap>,
-                <&kp M &kp S &kp E &kp D &kp G &kp E &kp RET>;
+                <&kp M>, <&kp S>, <&kp E>, <&kp D>, <&kp G>, <&kp E>, <&kp RET>;
         };
 
         col: tmux_column {
@@ -100,7 +98,7 @@
             #binding-cells = <0>;
             wait-ms = <0>;
             tap-ms = <0>;
-            bindings = <&macro_tap>, <&kp LC(A) &kp PIPE>;
+            bindings = <&macro_tap>, <&kp LC(A)>, <&kp PIPE>;
         };
 
         row: tmux_row {
@@ -108,7 +106,7 @@
             #binding-cells = <0>;
             wait-ms = <0>;
             tap-ms = <0>;
-            bindings = <&macro_tap>, <&kp LC(A) &kp MINUS>;
+            bindings = <&macro_tap>, <&kp LC(A)>, <&kp MINUS>;
         };
 
         list: tmux_list {
@@ -116,7 +114,7 @@
             #binding-cells = <0>;
             wait-ms = <0>;
             tap-ms = <0>;
-            bindings = <&macro_tap>, <&kp LC(A) &kp W>;
+            bindings = <&macro_tap>, <&kp LC(A)>, <&kp W>;
         };
 
         tabs: tmux_create {
@@ -124,7 +122,7 @@
             #binding-cells = <0>;
             wait-ms = <0>;
             tap-ms = <0>;
-            bindings = <&macro_tap>, <&kp LC(A) &kp C>;
+            bindings = <&macro_tap>, <&kp LC(A)>, <&kp C>;
         };
     };
 


### PR DESCRIPTION
- 以獨立的按鍵事件取代連鎖按鍵巨集，以提升清晰度和一致性。
- 修正按鍵組合的格式，改用逗號分隔按鍵，而非使用合併表達式。

Signed-off-by: Macbook Air <jackie@dast.tw>
