### PR TITLE
重構：優化巨集以提升清晰度、時間控制與擴充功能

### DIFF
--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -34,12 +34,9 @@
             wait-ms = <0>;
             tap-ms = <0>;
             bindings =
-                <&macro_press>,
-                <&kp LWIN>,
-                <&macro_tap>,
-                <&kp R>,
-                <&macro_release>,
-                <&kp LWIN>,
+                <&macro_press>, <&kp LWIN>,
+                <&macro_tap>, <&kp R>,
+                <&macro_release>, <&kp LWIN>,
                 <&macro_pause_for_release>,
                 <&macro_tap>,
                 <&kp W>, <&kp T>, <&kp RET>;
@@ -51,15 +48,16 @@
             wait-ms = <0>;
             tap-ms = <0>;
             bindings =
-                <&macro_press>,
-                <&kp LCMD>,
-                <&macro_tap>,
-                <&kp SPACE>,
-                <&macro_release>,
-                <&kp LCMD>,
+                <&macro_press>, <&kp LCMD>,
+                <&macro_tap>, <&kp SPACE>,
+                <&macro_release>, <&kp LCMD>,
                 <&macro_pause_for_release>,
+                <&macro_wait_time 150>,
                 <&macro_tap>,
-                <&kp G>, <&kp H>, <&kp O>, <&kp S>, <&kp T>, <&kp T>, <&kp Y>, <&kp RET>;
+                <&kp G>, <&kp H>, <&kp O>, <&kp S>, <&kp T>, <&kp T>, <&kp Y>,
+                <&kp DOT>, <&kp A>, <&kp P>, <&kp P>,
+                <&macro_wait_time 120>,
+                <&macro_tap>, <&kp RET>;
         };
 
         spot_mac: spotlight_macos {
@@ -68,12 +66,9 @@
             wait-ms = <0>;
             tap-ms = <0>;
             bindings =
-                <&macro_press>,
-                <&kp LCMD>,
-                <&macro_tap>,
-                <&kp SPACE>,
-                <&macro_release>,
-                <&kp LCMD>;
+                <&macro_press>, <&kp LCMD>,
+                <&macro_tap>, <&kp SPACE>,
+                <&macro_release>, <&kp LCMD>;
         }; 
 
         edge: start_edge {
@@ -82,12 +77,9 @@
             wait-ms = <0>;
             tap-ms = <0>;
             bindings =
-                <&macro_press>,
-                <&kp LWIN>,
-                <&macro_tap>,
-                <&kp R>,
-                <&macro_release>,
-                <&kp LWIN>,
+                <&macro_press>, <&kp LWIN>,
+                <&macro_tap>, <&kp R>,
+                <&macro_release>, <&kp LWIN>,
                 <&macro_pause_for_release>,
                 <&macro_tap>,
                 <&kp M>, <&kp S>, <&kp E>, <&kp D>, <&kp G>, <&kp E>, <&kp RET>;


### PR DESCRIPTION
- 將分離的巨集按壓、點擊及釋放綁定整合為單行，並與按鍵事件配對，以增進清晰度與一致性。
- 在 terminal_macos 巨集序列中新增等待時間，以改善按鍵事件間的時序。
- 擴充 terminal_macos 巨集綁定，新增 DOT、A 及雙重 P 按鍵，位於最終換行符之前。
- 對多個巨集的綁定進行微幅格式調整，提升可讀性與結構性。

Signed-off-by: Macbook Air <jackie@dast.tw>
