### PR TITLE
feat: 優化巨集快捷鍵並調整預設滑鼠移動時間

### DIFF
--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -23,7 +23,7 @@
 
 // Mouse settings
 
-#define ZMK_POINTING_DEFAULT_MOVE_VAL 1500  // default: 600
+#define ZMK_POINTING_DEFAULT_MOVE_VAL 1000  // default: 600
 #define ZMK_POINTING_DEFAULT_SCRL_VAL 20    // default: 10
 
 / {
@@ -34,10 +34,14 @@
             wait-ms = <0>;
             tap-ms = <0>;
             bindings =
+
+                // 開啟執行視窗
                 <&macro_press>, <&kp LWIN>,
                 <&macro_tap>, <&kp R>,
                 <&macro_release>, <&kp LWIN>,
                 <&macro_pause_for_release>,
+
+                // 輸入WT 後按下ENTER執行
                 <&macro_tap>,
                 <&kp W>, <&kp T>, <&kp RET>;
         };
@@ -45,16 +49,28 @@
         ter_mac: terminal_macos {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
+            wait-ms = <0>;
+            tap-ms = <0>;
             bindings =
+
+                // 開啟 Spotlight
                 <&macro_press>, <&kp LCMD>,
                 <&macro_tap>, <&kp SPACE>,
                 <&macro_release>, <&kp LCMD>,
                 <&macro_pause_for_release>,
-                <&macro_wait_time 150>,
+
+                // 等待 Spotlight 完全開啟
+                <&macro_wait_time 300>,
+
+                // 輸入 ghostty.app
                 <&macro_tap>,
                 <&kp G>, <&kp H>, <&kp O>, <&kp S>, <&kp T>, <&kp T>, <&kp Y>,
                 <&kp DOT>, <&kp A>, <&kp P>, <&kp P>,
-                <&macro_wait_time 120>,
+
+                // 等待 Spotlight 搜尋結果穩定
+                <&macro_wait_time 400>,
+
+                // 按下 Enter 啟動
                 <&macro_tap>, <&kp RET>;
         };
 
@@ -64,6 +80,8 @@
             wait-ms = <0>;
             tap-ms = <0>;
             bindings =
+
+                // 開啟 Spotlight
                 <&macro_press>, <&kp LCMD>,
                 <&macro_tap>, <&kp SPACE>,
                 <&macro_release>, <&kp LCMD>;
@@ -75,10 +93,14 @@
             wait-ms = <0>;
             tap-ms = <0>;
             bindings =
+
+                // 開啟執行視窗
                 <&macro_press>, <&kp LWIN>,
                 <&macro_tap>, <&kp R>,
                 <&macro_release>, <&kp LWIN>,
                 <&macro_pause_for_release>,
+
+                // 輸入msedge後按下Enter
                 <&macro_tap>,
                 <&kp M>, <&kp S>, <&kp E>, <&kp D>, <&kp G>, <&kp E>, <&kp RET>;
         };


### PR DESCRIPTION
- 將預設滑鼠移動時間從 1500 減少至 1000，捲動時間保持不變
- 新增多個用於終端機與應用程式快捷鍵的巨集，包括 Windows Terminal、macOS Spotlight 啟動 ghostty.app 及 Microsoft Edge
- 改善 macOS Spotlight 巨集的時序，增加等待時間以提升穩定性
- 在巨集的每個步驟中加入中文註解，說明開啟視窗、啟動應用程式及按下 Enter 鍵的用途

Signed-off-by: Macbook Air <jackie@dast.tw>
