### PR TITLE
重構：優化巨集與快速鍵以提升一致性

### DIFF
--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -28,7 +28,7 @@
 
 / {
     macros {
-        ter_wsl: terminal_windows {
+        edge: start_edge {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
             wait-ms = <0>;
@@ -40,6 +40,30 @@
                 <&macro_tap>, <&kp R>,
                 <&macro_release>, <&kp LWIN>,
                 <&macro_pause_for_release>,
+
+                // 等待 執行視窗 完全開啟
+                <&macro_wait_time 150>,
+                
+                // 輸入msedge後按下Enter
+                <&macro_tap>,
+                <&kp M>, <&kp S>, <&kp E>, <&kp D>, <&kp G>, <&kp E>, <&kp RET>;
+        };
+
+        ter_win: terminal_windows {
+            compatible = "zmk,behavior-macro";
+            #binding-cells = <0>;
+            wait-ms = <0>;
+            tap-ms = <0>;
+            bindings =
+
+                // 開啟執行視窗
+                <&macro_press>, <&kp LWIN>,
+                <&macro_tap>, <&kp R>,
+                <&macro_release>, <&kp LWIN>,
+                <&macro_pause_for_release>,
+
+                // 等待 執行視窗 完全開啟
+                <&macro_wait_time 150>,
 
                 // 輸入WT 後按下ENTER執行
                 <&macro_tap>,
@@ -60,7 +84,7 @@
                 <&macro_pause_for_release>,
 
                 // 等待 Spotlight 完全開啟
-                <&macro_wait_time 300>,
+                <&macro_wait_time 150>,
 
                 // 輸入 ghostty.app
                 <&macro_tap>,
@@ -68,13 +92,13 @@
                 <&kp DOT>, <&kp A>, <&kp P>, <&kp P>,
 
                 // 等待 Spotlight 搜尋結果穩定
-                <&macro_wait_time 400>,
+                <&macro_wait_time 300>,
 
                 // 按下 Enter 啟動
                 <&macro_tap>, <&kp RET>;
         };
 
-        spot_mac: spotlight_macos {
+        spotlight: spotlight {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
             wait-ms = <0>;
@@ -87,30 +111,13 @@
                 <&macro_release>, <&kp LCMD>;
         }; 
 
-        edge: start_edge {
-            compatible = "zmk,behavior-macro";
-            #binding-cells = <0>;
-            wait-ms = <0>;
-            tap-ms = <0>;
-            bindings =
-
-                // 開啟執行視窗
-                <&macro_press>, <&kp LWIN>,
-                <&macro_tap>, <&kp R>,
-                <&macro_release>, <&kp LWIN>,
-                <&macro_pause_for_release>,
-
-                // 輸入msedge後按下Enter
-                <&macro_tap>,
-                <&kp M>, <&kp S>, <&kp E>, <&kp D>, <&kp G>, <&kp E>, <&kp RET>;
-        };
-
         col: tmux_column {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
             wait-ms = <0>;
             tap-ms = <0>;
-            bindings = <&macro_tap>, <&kp LC(A)>, <&kp PIPE>;
+            bindings = 
+                <&macro_tap>, <&kp LC(A)>, <&kp PIPE>;
         };
 
         row: tmux_row {
@@ -118,7 +125,8 @@
             #binding-cells = <0>;
             wait-ms = <0>;
             tap-ms = <0>;
-            bindings = <&macro_tap>, <&kp LC(A)>, <&kp MINUS>;
+            bindings = 
+                <&macro_tap>, <&kp LC(A)>, <&kp MINUS>;
         };
 
         list: tmux_list {
@@ -126,7 +134,8 @@
             #binding-cells = <0>;
             wait-ms = <0>;
             tap-ms = <0>;
-            bindings = <&macro_tap>, <&kp LC(A)>, <&kp W>;
+            bindings = 
+                <&macro_tap>, <&kp LC(A)>, <&kp W>;
         };
 
         tabs: tmux_create {
@@ -134,7 +143,8 @@
             #binding-cells = <0>;
             wait-ms = <0>;
             tap-ms = <0>;
-            bindings = <&macro_tap>, <&kp LC(A)>, <&kp C>;
+            bindings = 
+                <&macro_tap>, <&kp LC(A)>, <&kp C>;
         };
     };
 
@@ -148,7 +158,7 @@
             &kp ESC    &kp N1  &kp N2  &kp N3    &kp N4        &kp N5                                         &kp N6           &kp N7   &kp N8     &kp N9   &kp N0    &kp MINUS
             &kp TAB    &kp Q   &kp W   &kp E     &kp R         &kp T                                          &kp Y            &kp U    &kp I      &kp O    &kp P     &kp LC(TAB)
             &kp LCTRL  &kp A   &kp S   &kp D     &kp F         &kp G                                          &kp H            &kp J    &kp K      &kp L    &kp SEMI  &kp C_PP
-            &kp LCTRL  &kp Z   &kp X   &kp C     &kp V         &kp B        &kp LC(LS(N2))     &ter_wsl       &kp N            &kp M    &kp COMMA  &kp DOT  &kp FSLH  &kp DEL
+            &kp LCTRL  &kp Z   &kp X   &kp C     &kp V         &kp B        &kp LC(LS(N2))     &ter_win       &kp N            &kp M    &kp COMMA  &kp DOT  &kp FSLH  &kp DEL
                                        &kp LWIN  &mt LALT ESC  &mo WinCode  &mt LSHFT SPACE    &mt LCTRL RET  &lt WinNav BSPC  &to SYS  &to MacDef
             >;
         };
@@ -184,7 +194,7 @@
             &kp ESC    &kp N1  &kp N2  &kp N3    &kp N4        &kp N5                                         &kp N6           &kp N7   &kp N8     &kp N9   &kp N0    &kp MINUS
             &kp TAB    &kp Q   &kp W   &kp E     &kp R         &kp T                                          &kp Y            &kp U    &kp I      &kp O    &kp P     &kp LC(TAB)
             &kp LCTRL  &kp A   &kp S   &kp D     &kp F         &kp G                                          &kp H            &kp J    &kp K      &kp L    &kp SEMI  &kp C_PP
-            &kp LCTRL  &kp Z   &kp X   &kp C     &kp V         &kp B        &spot_mac          &ter_mac       &kp N            &kp M    &kp COMMA  &kp DOT  &kp FSLH  &kp DEL
+            &kp LCTRL  &kp Z   &kp X   &kp C     &kp V         &kp B        &spotlight         &ter_mac       &kp N            &kp M    &kp COMMA  &kp DOT  &kp FSLH  &kp DEL
                                        &kp LALT  &mt LCMD ESC  &mo MacCode  &mt LSHFT SPACE    &mt LCTRL RET  &lt MacNav BSPC  &to SYS  &to WinDef
             >;
         };


### PR DESCRIPTION
- 新增一個巨集，透過特定鍵序啟動 Microsoft Edge。
- 調整現有巨集中的等待時間，縮短以提升響應速度。
- 重新命名並統一 spotlight 巨集名稱以確保一致性。
- 移除重複定義的啟動 Edge 巨集。
- 修正巨集快速鍵中的細微格式問題以提升可讀性。
- 將快速鍵綁定更改為使用新添加或重新命名的終端機與 spotlight 巨集。

Signed-off-by: Macbook Air <jackie@dast.tw>
