### PR TITLE
重構：將終端機按鍵綁定切換至原生 Windows 環境

### DIFF
--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -182,7 +182,7 @@
             &trans  &kp F1         &kp F2    &kp F3        &kp F4    &kp F5                       &kp F6        &kp F7        &kp F8      &kp F9      &kp F10           &kp F11
             &trans  &kp N1         &kp N2    &kp N3        &kp N4    &kp N5                       &kp N6        &kp N7        &kp N8      &kp N9      &kp N0            &kp F12
             &trans  &kp LG(LS(S))  &kp CAPS  &kp LG(UP)    &kp HOME  &kp PG_UP                    &kp LEFT      &kp DOWN      &kp UP      &kp RIGHT   &kp LC(LG(LEFT))  &kp LC(LG(RIGHT))
-            &trans  &ter_wsl       &edge     &kp LG(DOWN)  &kp END   &kp PG_DN  &trans    &trans  &kp C_VOL_DN  &kp C_VOL_UP  &kp C_PREV  &kp C_NEXT  &kp LC(LA(DEL))   &kp DEL
+            &trans  &ter_win       &edge     &kp LG(DOWN)  &kp END   &kp PG_DN  &trans    &trans  &kp C_VOL_DN  &kp C_VOL_UP  &kp C_PREV  &kp C_NEXT  &kp LC(LA(DEL))   &kp DEL
                                              &trans        &trans    &trans     &trans    &trans  &trans        &trans        &trans
             >;
         };


### PR DESCRIPTION
- 將按鍵配置中的終端機按鍵綁定，從 Windows Subsystem for Linux 替換為原生 Windows 環境。

Signed-off-by: Macbook Air <jackie@dast.tw>
