### PR TITLE
重構：交換並重新排列按鍵標籤與綁定以提高清晰度

### DIFF
--- a/IMG/lily58.svg
+++ b/IMG/lily58.svg
@@ -2148,11 +2148,11 @@ path.combo {
 </g>
 <g transform="translate(308, 154)" class="key keypos-29">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap"><tspan style="font-size: 64%">&amp;bootloader</tspan></text>
+<text x="0" y="0" class="key tap"><tspan style="font-size: 70%">&amp;sys_reset</tspan></text>
 </g>
 <g transform="translate(616, 154)" class="key keypos-30">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap"><tspan style="font-size: 64%">&amp;bootloader</tspan></text>
+<text x="0" y="0" class="key tap"><tspan style="font-size: 70%">&amp;sys_reset</tspan></text>
 </g>
 <g transform="translate(672, 147)" class="key keypos-31">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -2186,7 +2186,7 @@ path.combo {
 </g>
 <g transform="translate(308, 210)" class="key keypos-41">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap"><tspan style="font-size: 70%">&amp;sys_reset</tspan></text>
+<text x="0" y="0" class="key tap"><tspan style="font-size: 64%">&amp;bootloader</tspan></text>
 </g>
 <g transform="translate(364, 182)" class="key keypos-42">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -2196,7 +2196,7 @@ path.combo {
 </g>
 <g transform="translate(616, 210)" class="key keypos-44">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap"><tspan style="font-size: 70%">&amp;sys_reset</tspan></text>
+<text x="0" y="0" class="key tap"><tspan style="font-size: 64%">&amp;bootloader</tspan></text>
 </g>
 <g transform="translate(672, 203)" class="key keypos-45">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -253,8 +253,8 @@
             bindings = <
             &none  &none  &none  &none  &none  &bt BT_CLR                   &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4  &none
             &none  &none  &none  &none  &none  &none                        &none         &none         &none         &none         &none         &none
-            &none  &none  &none  &none  &none  &bootloader                  &bootloader   &none         &none         &none         &none         &none
-            &none  &none  &none  &none  &none  &sys_reset   &none    &none  &sys_reset    &none         &none         &none         &none         &none
+            &none  &none  &none  &none  &none  &sys_reset                   &sys_reset    &none         &none         &none         &none         &none
+            &none  &none  &none  &none  &none  &bootloader  &none    &none  &bootloader   &none         &none         &none         &none         &none
                                  &none  &none  &none        &none    &none  &to Game      &to MacDef    &to WinDef
             >;
         };


### PR DESCRIPTION
- 更新 SVG 按鍵標籤，透過交換特定按鍵中「bootloader」與「sys_reset」文字元素的位置與字體大小。
- 重新配置按鍵綁定，將 sys_reset 移至 bootloader 之前，並相應調整 keymap 配置中的順序。

Signed-off-by: WSL <jackie@dast.tw>
