### PR TITLE
chore：提升拉取請求自動化與觸發配置

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,32 +1,27 @@
----
 name: automerge
+
 on:
   pull_request:
     types:
       - labeled
-      - unlabeled
       - synchronize
       - opened
-      - edited
-      - ready_for_review
       - reopened
-      - unlocked
+      - ready_for_review
   pull_request_review:
-    types:
-      - submitted
+    types: [submitted]
   check_suite:
-    types:
-      - completed
+    types: [completed]
   status: {}
+
 jobs:
   automerge:
     runs-on: ubuntu-latest
     steps:
-      - id: automerge
-        name: automerge
+      - name: automerge
         uses: pascalgn/automerge-action@v0.16.4
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-          MERGE_LABELS: ''
-          MERGE_FILTER_AUTHOR: cloverdefa
-          MERGE_DELETE_BRANCH_FILTER: test
+          MERGE_LABELS: ""               # 不需要 label
+          MERGE_METHOD: "squash"         # merge squash rebase
+          MERGE_FILTER_AUTHOR: "cloverdefa"  # 只自動合併自己開的 PR


### PR DESCRIPTION
- 更新工作流程，加入 ready_for_review 事件至拉取請求觸發條件
- 將 automerge 作業改用名稱而非 ID
- 指定合併方式為壓縮合併（squash）以自動合併
- 保留現有過濾條件，僅自動合併由特定用戶建立的拉取請求
- 移除不必要的標籤配置與其他觸發類型於工作流程中

Signed-off-by: WSL <39210648+cloverdefa@users.noreply.github.com>
