### PR TITLE
style(svg): 修正 SVG 標籤拼寫錯誤並更新鍵位宏

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,32 +1,27 @@
----
 name: automerge
+
 on:
   pull_request:
     types:
       - labeled
-      - unlabeled
       - synchronize
       - opened
-      - edited
-      - ready_for_review
       - reopened
-      - unlocked
+      - ready_for_review
   pull_request_review:
-    types:
-      - submitted
+    types: [submitted]
   check_suite:
-    types:
-      - completed
+    types: [completed]
   status: {}
+
 jobs:
   automerge:
     runs-on: ubuntu-latest
     steps:
-      - id: automerge
-        name: automerge
+      - name: automerge
         uses: pascalgn/automerge-action@v0.16.4
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-          MERGE_LABELS: ''
-          MERGE_FILTER_AUTHOR: cloverdefa
-          MERGE_DELETE_BRANCH_FILTER: test
+          MERGE_LABELS: ""               # 不需要 label
+          MERGE_METHOD: "squash"         # merge squash rebase
+          MERGE_FILTER_AUTHOR: "cloverdefa"  # 只自動合併自己開的 PR

--- a/IMG/lily58.svg
+++ b/IMG/lily58.svg
@@ -68,25 +68,25 @@ text.footer {
 }
 
 /* styling for combo tap, and key non-tap label text */
-text.combo, text.hold, text.shifted, text.left, text.right {
+text.combo, text.hold, text.shifted, text.left, text.right, text.tl, text.tr, text.bl, text.br {
     font-size: 11px;
 }
 
-text.hold {
+text.hold, text.bl, text.br {
     text-anchor: middle;
     dominant-baseline: auto;
 }
 
-text.shifted {
+text.shifted, text.tl, text.tr {
     text-anchor: middle;
     dominant-baseline: hanging;
 }
 
-text.left {
+text.left, text.tl, text.bl {
     text-anchor: start;
 }
 
-text.right {
+text.right, text.tr, text.br {
     text-anchor: end;
 }
 

--- a/IMG/lily58.svg
+++ b/IMG/lily58.svg
@@ -297,9 +297,7 @@ path.combo {
 </g>
 <g transform="translate(364, 182)" class="key keypos-42">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">
-<tspan x="0" dy="-0.6em">Ctl+Sft</tspan><tspan x="0" dy="1.2em">+2</tspan>
-</text>
+<text x="0" y="0" class="key tap"><tspan style="font-size: 64%">&amp;spotlight…</tspan></text>
 </g>
 <g transform="translate(560, 182)" class="key keypos-43">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -361,15 +359,9 @@ path.combo {
 </a></g>
 <g transform="translate(700, 260)" class="key keypos-56">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<a href="#Mouse">
-<text x="0" y="0" class="key tap layer-activator">Mouse</text>
-</a><text x="0" y="24" class="key hold">toggle</text>
 </g>
 <g transform="translate(756, 260)" class="key keypos-57">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<a href="#MacOS">
-<text x="0" y="0" class="key tap layer-activator">MacOS</text>
-</a><text x="0" y="24" class="key hold">toggle</text>
 </g>
 </g>
 </g>
@@ -602,17 +594,13 @@ path.combo {
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
 <text x="0" y="0" class="key trans tap">▽</text>
 </g>
-<g transform="translate(700, 260)" class="key keypos-56">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<a href="#Game">
-<text x="0" y="0" class="key tap layer-activator">Game</text>
-</a><text x="0" y="24" class="key hold">toggle</text>
+<g transform="translate(700, 260)" class="key trans keypos-56">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
 </g>
-<g transform="translate(756, 260)" class="key keypos-57">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<a href="#System">
-<text x="0" y="0" class="key tap layer-activator">System</text>
-</a><text x="0" y="24" class="key hold">toggle</text>
+<g transform="translate(756, 260)" class="key trans keypos-57">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
 </g>
 </g>
 </g>
@@ -845,13 +833,17 @@ path.combo {
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
 <text x="0" y="0" class="key trans tap">▽</text>
 </g>
-<g transform="translate(280, 266)" class="key trans keypos-52">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
-<text x="0" y="0" class="key trans tap">▽</text>
+<g transform="translate(280, 266)" class="key keypos-52">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<a href="#Mouse">
+<text x="0" y="0" class="key tap layer-activator">Mouse</text>
+</a><text x="0" y="24" class="key hold">toggle</text>
 </g>
-<g transform="translate(350, 266) rotate(30.0)" class="key trans keypos-53">
-<rect rx="6" ry="6" x="-26" y="-40" width="52" height="80" class="key trans"/>
-<text x="0" y="0" class="key trans tap">▽</text>
+<g transform="translate(350, 266) rotate(30.0)" class="key keypos-53">
+<rect rx="6" ry="6" x="-26" y="-40" width="52" height="80" class="key"/>
+<a href="#System">
+<text x="0" y="0" class="key tap layer-activator">System</text>
+</a><text x="0" y="38" class="key hold">toggle</text>
 </g>
 <g transform="translate(574, 266) rotate(-30.0)" class="key trans keypos-54">
 <rect rx="6" ry="6" x="-26" y="-40" width="52" height="80" class="key trans"/>
@@ -1105,15 +1097,9 @@ path.combo {
 </a></g>
 <g transform="translate(700, 260)" class="key keypos-56">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<a href="#Mouse">
-<text x="0" y="0" class="key tap layer-activator">Mouse</text>
-</a><text x="0" y="24" class="key hold">toggle</text>
 </g>
 <g transform="translate(756, 260)" class="key keypos-57">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<a href="#Windows">
-<text x="0" y="0" class="key tap layer-activator">Windows</text>
-</a><text x="0" y="24" class="key hold">toggle</text>
 </g>
 </g>
 </g>
@@ -1346,17 +1332,13 @@ path.combo {
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
 <text x="0" y="0" class="key trans tap">▽</text>
 </g>
-<g transform="translate(700, 260)" class="key keypos-56">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<a href="#Game">
-<text x="0" y="0" class="key tap layer-activator">Game</text>
-</a><text x="0" y="24" class="key hold">toggle</text>
+<g transform="translate(700, 260)" class="key trans keypos-56">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
 </g>
-<g transform="translate(756, 260)" class="key keypos-57">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<a href="#System">
-<text x="0" y="0" class="key tap layer-activator">System</text>
-</a><text x="0" y="24" class="key hold">toggle</text>
+<g transform="translate(756, 260)" class="key trans keypos-57">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
+<text x="0" y="0" class="key trans tap">▽</text>
 </g>
 </g>
 </g>
@@ -1590,13 +1572,17 @@ path.combo {
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
 <text x="0" y="0" class="key trans tap">▽</text>
 </g>
-<g transform="translate(280, 266)" class="key trans keypos-52">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
-<text x="0" y="0" class="key trans tap">▽</text>
+<g transform="translate(280, 266)" class="key keypos-52">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<a href="#Mouse">
+<text x="0" y="0" class="key tap layer-activator">Mouse</text>
+</a><text x="0" y="24" class="key hold">toggle</text>
 </g>
-<g transform="translate(350, 266) rotate(30.0)" class="key trans keypos-53">
-<rect rx="6" ry="6" x="-26" y="-40" width="52" height="80" class="key trans"/>
-<text x="0" y="0" class="key trans tap">▽</text>
+<g transform="translate(350, 266) rotate(30.0)" class="key keypos-53">
+<rect rx="6" ry="6" x="-26" y="-40" width="52" height="80" class="key"/>
+<a href="#System">
+<text x="0" y="0" class="key tap layer-activator">System</text>
+</a><text x="0" y="38" class="key hold">toggle</text>
 </g>
 <g transform="translate(574, 266) rotate(-30.0)" class="key trans keypos-54">
 <rect rx="6" ry="6" x="-26" y="-40" width="52" height="80" class="key trans"/>
@@ -2220,33 +2206,33 @@ path.combo {
 </g>
 <g transform="translate(224, 260)" class="key keypos-51">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<a href="#MacOS">
+<text x="0" y="0" class="key tap layer-activator">MacOS</text>
+</a><text x="0" y="24" class="key hold">toggle</text>
 </g>
 <g transform="translate(280, 266)" class="key keypos-52">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<a href="#Game">
+<text x="0" y="0" class="key tap layer-activator">Game</text>
+</a><text x="0" y="24" class="key hold">toggle</text>
 </g>
 <g transform="translate(350, 266) rotate(30.0)" class="key keypos-53">
 <rect rx="6" ry="6" x="-26" y="-40" width="52" height="80" class="key"/>
+<a href="#Windows">
+<text x="0" y="0" class="key tap layer-activator">Windows</text>
+</a><text x="0" y="38" class="key hold">toggle</text>
 </g>
 <g transform="translate(574, 266) rotate(-30.0)" class="key keypos-54">
 <rect rx="6" ry="6" x="-26" y="-40" width="52" height="80" class="key"/>
 </g>
 <g transform="translate(644, 266)" class="key keypos-55">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<a href="#Game">
-<text x="0" y="0" class="key tap layer-activator">Game</text>
-</a><text x="0" y="24" class="key hold">toggle</text>
 </g>
 <g transform="translate(700, 260)" class="key keypos-56">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<a href="#MacOS">
-<text x="0" y="0" class="key tap layer-activator">MacOS</text>
-</a><text x="0" y="24" class="key hold">toggle</text>
 </g>
 <g transform="translate(756, 260)" class="key keypos-57">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<a href="#Windows">
-<text x="0" y="0" class="key tap layer-activator">Windows</text>
-</a><text x="0" y="24" class="key hold">toggle</text>
 </g>
 </g>
 </g>

--- a/IMG/lily58.svg
+++ b/IMG/lily58.svg
@@ -361,8 +361,8 @@ path.combo {
 </a></g>
 <g transform="translate(700, 260)" class="key keypos-56">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<a href="#System">
-<text x="0" y="0" class="key tap layer-activator">System</text>
+<a href="#Mouse">
+<text x="0" y="0" class="key tap layer-activator">Mouse</text>
 </a><text x="0" y="24" class="key hold">toggle</text>
 </g>
 <g transform="translate(756, 260)" class="key keypos-57">
@@ -572,9 +572,6 @@ path.combo {
 </g>
 <g transform="translate(840, 217)" class="key keypos-48">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<a href="#Mouse">
-<text x="0" y="0" class="key tap layer-activator">Mouse</text>
-</a><text x="0" y="24" class="key hold">toggle</text>
 </g>
 <g transform="translate(896, 224)" class="key keypos-49">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -611,9 +608,11 @@ path.combo {
 <text x="0" y="0" class="key tap layer-activator">Game</text>
 </a><text x="0" y="24" class="key hold">toggle</text>
 </g>
-<g transform="translate(756, 260)" class="key trans keypos-57">
-<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
-<text x="0" y="0" class="key trans tap">▽</text>
+<g transform="translate(756, 260)" class="key keypos-57">
+<rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<a href="#System">
+<text x="0" y="0" class="key tap layer-activator">System</text>
+</a><text x="0" y="24" class="key hold">toggle</text>
 </g>
 </g>
 </g>
@@ -1106,8 +1105,8 @@ path.combo {
 </a></g>
 <g transform="translate(700, 260)" class="key keypos-56">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<a href="#System">
-<text x="0" y="0" class="key tap layer-activator">System</text>
+<a href="#Mouse">
+<text x="0" y="0" class="key tap layer-activator">Mouse</text>
 </a><text x="0" y="24" class="key hold">toggle</text>
 </g>
 <g transform="translate(756, 260)" class="key keypos-57">
@@ -1314,12 +1313,15 @@ path.combo {
 </g>
 <g transform="translate(840, 217)" class="key keypos-48">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<a href="#Mouse">
-<text x="0" y="0" class="key tap layer-activator">Mouse</text>
-</a><text x="0" y="24" class="key hold">toggle</text>
+<text x="0" y="0" class="key tap">
+<tspan x="0" dy="-0.6em">Gui+</tspan><tspan x="0" dy="1.2em">SPACE</tspan>
+</text>
 </g>
 <g transform="translate(896, 224)" class="key keypos-49">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
+<text x="0" y="0" class="key tap">
+<tspan x="0" dy="-0.6em">Gui+Sft</tspan><tspan x="0" dy="1.2em">+T</tspan>
+</text>
 </g>
 <g transform="translate(168, 259)" class="key trans keypos-50">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key trans"/>
@@ -1346,15 +1348,15 @@ path.combo {
 </g>
 <g transform="translate(700, 260)" class="key keypos-56">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">
-<tspan x="0" dy="-0.6em">Gui+</tspan><tspan x="0" dy="1.2em">SPACE</tspan>
-</text>
+<a href="#Game">
+<text x="0" y="0" class="key tap layer-activator">Game</text>
+</a><text x="0" y="24" class="key hold">toggle</text>
 </g>
 <g transform="translate(756, 260)" class="key keypos-57">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">
-<tspan x="0" dy="-0.6em">Gui+Sft</tspan><tspan x="0" dy="1.2em">+T</tspan>
-</text>
+<a href="#System">
+<text x="0" y="0" class="key tap layer-activator">System</text>
+</a><text x="0" y="24" class="key hold">toggle</text>
 </g>
 </g>
 </g>

--- a/IMG/lily58.svg
+++ b/IMG/lily58.svg
@@ -297,11 +297,13 @@ path.combo {
 </g>
 <g transform="translate(364, 182)" class="key keypos-42">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap"><tspan style="font-size: 64%">&amp;spotlight…</tspan></text>
+<text x="0" y="0" class="key tap">
+<tspan x="0" dy="-0.6em">Sft+Ctl</tspan><tspan x="0" dy="1.2em">+2</tspan>
+</text>
 </g>
 <g transform="translate(560, 182)" class="key keypos-43">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap"><tspan style="font-size: 88%">&amp;ter_win</tspan></text>
+<text x="0" y="0" class="key tap"><tspan style="font-size: 64%">&amp;spotlight…</tspan></text>
 </g>
 <g transform="translate(616, 210)" class="key keypos-44">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>

--- a/IMG/lily58.svg
+++ b/IMG/lily58.svg
@@ -301,7 +301,7 @@ path.combo {
 </g>
 <g transform="translate(560, 182)" class="key keypos-43">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">&amp;ptrun</text>
+<text x="0" y="0" class="key tap">&amp;pt_run</text>
 </g>
 <g transform="translate(616, 210)" class="key keypos-44">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>

--- a/IMG/lily58.svg
+++ b/IMG/lily58.svg
@@ -297,13 +297,11 @@ path.combo {
 </g>
 <g transform="translate(364, 182)" class="key keypos-42">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap">
-<tspan x="0" dy="-0.6em">Sft+Ctl</tspan><tspan x="0" dy="1.2em">+2</tspan>
-</text>
+<text x="0" y="0" class="key tap"><tspan style="font-size: 88%">&amp;cal_win</tspan></text>
 </g>
 <g transform="translate(560, 182)" class="key keypos-43">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap"><tspan style="font-size: 64%">&amp;spotlight…</tspan></text>
+<text x="0" y="0" class="key tap">&amp;ptrun</text>
 </g>
 <g transform="translate(616, 210)" class="key keypos-44">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
@@ -1041,7 +1039,7 @@ path.combo {
 </g>
 <g transform="translate(560, 182)" class="key keypos-43">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>
-<text x="0" y="0" class="key tap"><tspan style="font-size: 88%">&amp;ter_mac</tspan></text>
+<text x="0" y="0" class="key tap"><tspan style="font-size: 70%">&amp;spotlight</tspan></text>
 </g>
 <g transform="translate(616, 210)" class="key keypos-44">
 <rect rx="6" ry="6" x="-26" y="-26" width="52" height="52" class="key"/>

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -123,6 +123,19 @@
                 <&macro_release>, <&kp LCMD>;
         }; 
 
+        spotlight_win: spotlight_win {
+            compatible = "zmk,behavior-macro";
+            #binding-cells = <0>;
+            wait-ms = <0>;
+            tap-ms = <0>;
+            bindings =
+
+                // 開啟 Spotlight
+                <&macro_press>, <&kp LWIN>, <&kp LALT>,
+                <&macro_tap>, <&kp SPACE>,
+                <&macro_release>, <&kp LWIN>, <&kp LALT;
+        }; 
+
         col: tmux_column {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
@@ -170,7 +183,7 @@
             &kp ESC    &kp N1  &kp N2  &kp N3    &kp N4        &kp N5                                         &kp N6           &kp N7     &kp N8     &kp N9   &kp N0    &kp MINUS
             &kp TAB    &kp Q   &kp W   &kp E     &kp R         &kp T                                          &kp Y            &kp U      &kp I      &kp O    &kp P     &kp LC(TAB)
             &kp LCTRL  &kp A   &kp S   &kp D     &kp F         &kp G                                          &kp H            &kp J      &kp K      &kp L    &kp SEMI  &kp C_PP
-            &kp LCTRL  &kp Z   &kp X   &kp C     &kp V         &kp B        &kp LC(LS(N2))     &ter_win       &kp N            &kp M      &kp COMMA  &kp DOT  &kp FSLH  &kp DEL
+            &kp LCTRL  &kp Z   &kp X   &kp C     &kp V         &kp B        &spotlight_win     &ter_win       &kp N            &kp M      &kp COMMA  &kp DOT  &kp FSLH  &kp DEL
                                        &kp LWIN  &mt LALT ESC  &mo WinCode  &mt LSHFT SPACE    &mt LCTRL RET  &lt WinNav BSPC  &none      &none
             >;
         };

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -150,7 +150,7 @@
                 &kp ESC    &kp N1  &kp N2  &kp N3    &kp N4        &kp N5                                          &kp N6           &kp N7  &kp N8     &kp N9   &kp N0    &kp MINUS
                 &kp TAB    &kp Q   &kp W   &kp E     &kp R         &kp T                                           &kp Y            &kp U   &kp I      &kp O    &kp P     &kp LC(TAB)
                 &kp LCTRL  &kp A   &kp S   &kp D     &kp F         &kp G                                           &kp H            &kp J   &kp K      &kp L    &kp SEMI  &kp C_PP
-                &kp LCTRL  &kp Z   &kp X   &kp C     &kp V         &kp B        &kp LS(LC(2))      &spotlight_win  &kp N            &kp M   &kp COMMA  &kp DOT  &kp FSLH  &kp DEL
+                &kp LCTRL  &kp Z   &kp X   &kp C     &kp V         &kp B        &kp LS(LC(N2))      &spotlight_win  &kp N            &kp M   &kp COMMA  &kp DOT  &kp FSLH  &kp DEL
                                            &kp LWIN  &mt LALT ESC  &mo WinCode  &mt LSHFT SPACE    &mt LCTRL RET   &lt WinNav BSPC  &none   &none
             >;
         };

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -42,8 +42,8 @@
                 <&kp LALT>,
                 <&macro_pause_for_release>,
                 <&macro_tap>,
-                <&kp E &kp D &kp G &kp E>,
-                <&macro_wait_time 200>,
+                <&kp DOT &kp E &kp D &kp G &kp E>,
+                <&macro_wait_time 300>,
                 <&kp RET>;
         };
 
@@ -61,8 +61,8 @@
                 <&kp LALT>,
                 <&macro_pause_for_release>,
                 <&macro_tap>,
-                <&kp W>, <&kp T>,
-                <&macro_wait_time 200>,
+                <&kp DOT &kp W>, <&kp T>,
+                <&macro_wait_time 300>,
                 <&kp RET>;
         };
 
@@ -79,7 +79,6 @@
                 <&macro_release>,
                 <&kp LCMD>,
                 <&macro_pause_for_release>,
-                <&macro_wait_time 200>,
                 <&macro_tap>,
                 <&kp G &kp H &kp O &kp S &kp T &kp T &kp Y &kp DOT &kp A &kp P &kp P>,
                 <&macro_wait_time 300>,

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -42,7 +42,7 @@
                 <&kp LALT>,
                 <&macro_pause_for_release>,
                 <&macro_tap>,
-                <&kp BSPC &kp E &kp D &kp G &kp E &kp RET>;
+                <&kp LS(M) &kp I &kp C &kp R &kp O &kp S &kp O &kp F &kp T &kp SPACE &kp LS(E) &kp D &kp G &kp E &kp RET>;
         };
 
         ter_win: terminal_windows {
@@ -59,7 +59,7 @@
                 <&kp LALT>,
                 <&macro_pause_for_release>,
                 <&macro_tap>,
-                <&kp BSPC &kp W &kp T &kp RET>;
+                <&kp W &kp T &kp DOT &kp E &kp X &kp E &kp RET>;
         };
 
         ter_mac: terminal_macos {

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -41,7 +41,7 @@
                 <&macro_release>,
                 <&kp LA(LWIN)>,
                 <&macro_pause_for_release>,
-                <&macro_wait_time 250>,
+                <&macro_wait_time 150>,
                 <&macro_tap>,
                 <&kp E &kp D &kp G &kp E &kp RET>;
         };
@@ -59,7 +59,7 @@
                 <&macro_release>,
                 <&kp LA(LWIN)>,
                 <&macro_pause_for_release>,
-                <&macro_wait_time 250>,
+                <&macro_wait_time 150>,
                 <&macro_tap>,
                 <&kp W &kp T &kp DOT &kp E &kp X &kp E &kp RET>;
         };
@@ -77,7 +77,7 @@
                 <&macro_release>,
                 <&kp LCMD>,
                 <&macro_pause_for_release>,
-                <&macro_wait_time 250>,
+                <&macro_wait_time 150>,
                 <&macro_tap>,
                 <&kp BSPC &kp G &kp H &kp O &kp S &kp T &kp T &kp Y &kp DOT &kp A &kp P &kp P &kp RET>;
         };

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -35,17 +35,14 @@
             tap-ms = <0>;
             bindings =
                 <&macro_press>,
-                <&kp LWIN>,
+                <&kp LALT>,
                 <&macro_tap>,
-                <&kp R>,
+                <&kp SPACE>,
                 <&macro_release>,
-                <&kp LWIN>,
+                <&kp LALT>,
                 <&macro_pause_for_release>,
-                <&macro_wait_time 150>,
                 <&macro_tap>,
-                <&kp M &kp S &kp E &kp D &kp G &kp E>,
-                <&macro_wait_time 300>,
-                <&macro_tap>,
+                <&kp E &kp D &kp G &kp E>,
                 <&kp RET>;
         };
 

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -5,8 +5,8 @@
  */
 
 #include <behaviors.dtsi>
-#include <dt-bindings/zmk/keys.h>
 #include <dt-bindings/zmk/bt.h>
+#include <dt-bindings/zmk/keys.h>
 #include <dt-bindings/zmk/pointing.h>
 
 // Layers
@@ -34,25 +34,19 @@
             wait-ms = <0>;
             tap-ms = <0>;
             bindings =
-
-                // 開啟執行視窗
-                <&macro_press>, <&kp LWIN>,
-                <&macro_tap>, <&kp R>,
-                <&macro_release>, <&kp LWIN>,
-                <&macro_pause_for_release>,
-
-                // 等待 執行視窗 完全開啟
-                <&macro_wait_time 150>,
-                
-                // 輸入msedge
+                <&macro_press>,
+                <&kp LWIN>,
                 <&macro_tap>,
-                <&kp M>, <&kp S>, <&kp E>, <&kp D>, <&kp G>, <&kp E>,
-
-                // 等待 搜尋視窗 搜尋結果穩定
+                <&kp R>,
+                <&macro_release>,
+                <&kp LWIN>,
+                <&macro_pause_for_release>,
+                <&macro_wait_time 150>,
+                <&macro_tap>,
+                <&kp M &kp S &kp E &kp D &kp G &kp E>,
                 <&macro_wait_time 300>,
-
-                // 按下 Enter 啟動
-                <&macro_tap>, <&kp RET>;        
+                <&macro_tap>,
+                <&kp RET>;
         };
 
         ter_win: terminal_windows {
@@ -61,25 +55,19 @@
             wait-ms = <0>;
             tap-ms = <0>;
             bindings =
-
-                // 開啟執行視窗
-                <&macro_press>, <&kp LWIN>,
-                <&macro_tap>, <&kp R>,
-                <&macro_release>, <&kp LWIN>,
-                <&macro_pause_for_release>,
-
-                // 等待 執行視窗 完全開啟
-                <&macro_wait_time 150>,
-
-                // 輸入WT
+                <&macro_press>,
+                <&kp LWIN>,
                 <&macro_tap>,
-                <&kp W>, <&kp T>,
-
-                // 等待 搜尋視窗 搜尋結果穩定
+                <&kp R>,
+                <&macro_release>,
+                <&kp LWIN>,
+                <&macro_pause_for_release>,
+                <&macro_wait_time 150>,
+                <&macro_tap>,
+                <&kp W &kp T>,
                 <&macro_wait_time 300>,
-
-                // 按下 Enter 啟動
-                <&macro_tap>, <&kp RET>;
+                <&macro_tap>,
+                <&kp RET>;
         };
 
         ter_mac: terminal_macos {
@@ -88,26 +76,19 @@
             wait-ms = <0>;
             tap-ms = <0>;
             bindings =
-
-                // 開啟 Spotlight
-                <&macro_press>, <&kp LCMD>,
-                <&macro_tap>, <&kp SPACE>,
-                <&macro_release>, <&kp LCMD>,
-                <&macro_pause_for_release>,
-
-                // 等待 Spotlight 完全開啟
-                <&macro_wait_time 150>,
-
-                // 輸入 ghostty.app
+                <&macro_press>,
+                <&kp LCMD>,
                 <&macro_tap>,
-                <&kp G>, <&kp H>, <&kp O>, <&kp S>, <&kp T>, <&kp T>, <&kp Y>,
-                <&kp DOT>, <&kp A>, <&kp P>, <&kp P>,
-
-                // 等待 Spotlight 搜尋結果穩定
+                <&kp SPACE>,
+                <&macro_release>,
+                <&kp LCMD>,
+                <&macro_pause_for_release>,
+                <&macro_wait_time 150>,
+                <&macro_tap>,
+                <&kp G &kp H &kp O &kp S &kp T &kp T &kp Y &kp DOT &kp A &kp P &kp P>,
                 <&macro_wait_time 300>,
-
-                // 按下 Enter 啟動
-                <&macro_tap>, <&kp RET>;
+                <&macro_tap>,
+                <&kp RET>;
         };
 
         spotlight: spotlight {
@@ -116,12 +97,13 @@
             wait-ms = <0>;
             tap-ms = <0>;
             bindings =
-
-                // 開啟 Spotlight
-                <&macro_press>, <&kp LCMD>,
-                <&macro_tap>, <&kp SPACE>,
-                <&macro_release>, <&kp LCMD>;
-        }; 
+                <&macro_press>,
+                <&kp LCMD>,
+                <&macro_tap>,
+                <&kp SPACE>,
+                <&macro_release>,
+                <&kp LCMD>;
+        };
 
         spotlight_win: spotlight_win {
             compatible = "zmk,behavior-macro";
@@ -129,20 +111,20 @@
             wait-ms = <0>;
             tap-ms = <0>;
             bindings =
-
-                // 開啟 Spotlight
-                <&macro_press>, <&kp LWIN>, <&kp LALT>,
-                <&macro_tap>, <&kp SPACE>,
-                <&macro_release>, <&kp LWIN>, <&kp LALT>;
-        }; 
+                <&macro_press>,
+                <&kp LWIN &kp LALT>,
+                <&macro_tap>,
+                <&kp SPACE>,
+                <&macro_release>,
+                <&kp LWIN &kp LALT>;
+        };
 
         col: tmux_column {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
             wait-ms = <0>;
             tap-ms = <0>;
-            bindings = 
-                <&macro_tap>, <&kp LC(A)>, <&kp PIPE>;
+            bindings = <&macro_tap>, <&kp LC(A) &kp PIPE>;
         };
 
         row: tmux_row {
@@ -150,8 +132,7 @@
             #binding-cells = <0>;
             wait-ms = <0>;
             tap-ms = <0>;
-            bindings = 
-                <&macro_tap>, <&kp LC(A)>, <&kp MINUS>;
+            bindings = <&macro_tap>, <&kp LC(A) &kp MINUS>;
         };
 
         list: tmux_list {
@@ -159,8 +140,7 @@
             #binding-cells = <0>;
             wait-ms = <0>;
             tap-ms = <0>;
-            bindings = 
-                <&macro_tap>, <&kp LC(A)>, <&kp W>;
+            bindings = <&macro_tap>, <&kp LC(A) &kp W>;
         };
 
         tabs: tmux_create {
@@ -168,83 +148,82 @@
             #binding-cells = <0>;
             wait-ms = <0>;
             tap-ms = <0>;
-            bindings = 
-                <&macro_tap>, <&kp LC(A)>, <&kp C>;
+            bindings = <&macro_tap>, <&kp LC(A) &kp C>;
         };
     };
 
     keymap {
         compatible = "zmk,keymap";
 
-        WinDef_layer {
+        WindowsDef_layer {
             label = "WinDef";
             display-name = "Windows";
             bindings = <
-            &kp ESC    &kp N1  &kp N2  &kp N3    &kp N4        &kp N5                                         &kp N6           &kp N7     &kp N8     &kp N9   &kp N0    &kp MINUS
-            &kp TAB    &kp Q   &kp W   &kp E     &kp R         &kp T                                          &kp Y            &kp U      &kp I      &kp O    &kp P     &kp LC(TAB)
-            &kp LCTRL  &kp A   &kp S   &kp D     &kp F         &kp G                                          &kp H            &kp J      &kp K      &kp L    &kp SEMI  &kp C_PP
-            &kp LCTRL  &kp Z   &kp X   &kp C     &kp V         &kp B        &spotlight_win     &ter_win       &kp N            &kp M      &kp COMMA  &kp DOT  &kp FSLH  &kp DEL
-                                       &kp LWIN  &mt LALT ESC  &mo WinCode  &mt LSHFT SPACE    &mt LCTRL RET  &lt WinNav BSPC  &none      &none
+&kp ESC    &kp N1  &kp N2  &kp N3    &kp N4        &kp N5                                         &kp N6           &kp N7  &kp N8     &kp N9   &kp N0    &kp MINUS
+&kp TAB    &kp Q   &kp W   &kp E     &kp R         &kp T                                          &kp Y            &kp U   &kp I      &kp O    &kp P     &kp LC(TAB)
+&kp LCTRL  &kp A   &kp S   &kp D     &kp F         &kp G                                          &kp H            &kp J   &kp K      &kp L    &kp SEMI  &kp C_PP
+&kp LCTRL  &kp Z   &kp X   &kp C     &kp V         &kp B        &spotlight_win     &ter_win       &kp N            &kp M   &kp COMMA  &kp DOT  &kp FSLH  &kp DEL
+                           &kp LWIN  &mt LALT ESC  &mo WinCode  &mt LSHFT SPACE    &mt LCTRL RET  &lt WinNav BSPC  &none   &none
             >;
         };
 
-        WinCode_layer {
+        WindowsCode_layer {
             label = "WinCode";
             display-name = "WinCode";
             bindings = <
-            &trans  &kp F1    &kp F2  &kp F3     &kp F4     &kp F5                       &kp F6     &kp F7    &kp F8    &kp F9    &kp F10     &kp F11
-            &trans  &kp EXCL  &kp AT  &kp HASH   &kp DLLR   &kp PRCNT                    &kp CARET  &kp AMPS  &kp STAR  &kp LPAR  &kp RPAR    &kp F12
-            &trans  &list     &col    &kp GRAVE  &kp MINUS  &kp EQUAL                    &kp LBRC   &kp RBRC  &kp SQT   &kp DQT   &kp LA(F4)  &kp LC(LG(D))
-            &trans  &tabs     &row    &kp TILDE  &kp PLUS   &kp UNDER  &trans    &trans  &kp LBKT   &kp RBKT  &kp PIPE  &kp BSLH  &none       &kp LC(LG(F4))
-                                      &trans     &trans     &trans     &trans    &trans  &trans     &trans    &trans
+&trans  &kp F1    &kp F2  &kp F3     &kp F4     &kp F5                       &kp F6     &kp F7    &kp F8    &kp F9    &kp F10     &kp F11
+&trans  &kp EXCL  &kp AT  &kp HASH   &kp DLLR   &kp PRCNT                    &kp CARET  &kp AMPS  &kp STAR  &kp LPAR  &kp RPAR    &kp F12
+&trans  &list     &col    &kp GRAVE  &kp MINUS  &kp EQUAL                    &kp LBRC   &kp RBRC  &kp SQT   &kp DQT   &kp LA(F4)  &kp LC(LG(D))
+&trans  &tabs     &row    &kp TILDE  &kp PLUS   &kp UNDER  &trans    &trans  &kp LBKT   &kp RBKT  &kp PIPE  &kp BSLH  &none       &kp LC(LG(F4))
+                          &trans     &trans     &trans     &trans    &trans  &trans     &trans    &trans
             >;
         };
 
-        WinNAV_layer {
+        WindowsNAV_layer {
             label = "WinNAV";
             display-name = "WinNAV";
             bindings = <
-            &trans  &kp F1         &kp F2    &kp F3        &kp F4    &kp F5                        &kp F6        &kp F7        &kp F8      &kp F9      &kp F10           &kp F11
-            &trans  &kp N1         &kp N2    &kp N3        &kp N4    &kp N5                        &kp N6        &kp N7        &kp N8      &kp N9      &kp N0            &kp F12
-            &trans  &kp LG(LS(S))  &kp CAPS  &kp LG(UP)    &kp HOME  &kp PG_UP                     &kp LEFT      &kp DOWN      &kp UP      &kp RIGHT   &kp LC(LG(LEFT))  &kp LC(LG(RIGHT))
-            &trans  &ter_win       &edge     &kp LG(DOWN)  &kp END   &kp PG_DN  &trans     &trans  &kp C_VOL_DN  &kp C_VOL_UP  &kp C_PREV  &kp C_NEXT  &kp LC(LA(DEL))   &kp DEL
-                                             &trans        &trans    &to Mouse  &to SYS    &trans  &trans        &trans        &trans
+&trans  &kp F1         &kp F2    &kp F3        &kp F4    &kp F5                        &kp F6        &kp F7        &kp F8      &kp F9      &kp F10           &kp F11
+&trans  &kp N1         &kp N2    &kp N3        &kp N4    &kp N5                        &kp N6        &kp N7        &kp N8      &kp N9      &kp N0            &kp F12
+&trans  &kp LG(LS(S))  &kp CAPS  &kp LG(UP)    &kp HOME  &kp PG_UP                     &kp LEFT      &kp DOWN      &kp UP      &kp RIGHT   &kp LC(LG(LEFT))  &kp LC(LG(RIGHT))
+&trans  &ter_win       &edge     &kp LG(DOWN)  &kp END   &kp PG_DN  &trans     &trans  &kp C_VOL_DN  &kp C_VOL_UP  &kp C_PREV  &kp C_NEXT  &kp LC(LA(DEL))   &kp DEL
+                                 &trans        &trans    &to Mouse  &to SYS    &trans  &trans        &trans        &trans
             >;
         };
 
-        MacDef_layer {
+        MacbookDef_layer {
             label = "MacDef";
             display-name = "MacOS";
             bindings = <
-            &kp ESC    &kp N1  &kp N2  &kp N3    &kp N4        &kp N5                                         &kp N6           &kp N7  &kp N8     &kp N9   &kp N0    &kp MINUS
-            &kp TAB    &kp Q   &kp W   &kp E     &kp R         &kp T                                          &kp Y            &kp U   &kp I      &kp O    &kp P     &kp LC(TAB)
-            &kp LCTRL  &kp A   &kp S   &kp D     &kp F         &kp G                                          &kp H            &kp J   &kp K      &kp L    &kp SEMI  &kp C_PP
-            &kp LCTRL  &kp Z   &kp X   &kp C     &kp V         &kp B        &spotlight         &ter_mac       &kp N            &kp M   &kp COMMA  &kp DOT  &kp FSLH  &kp DEL
-                                       &kp LALT  &mt LCMD ESC  &mo MacCode  &mt LSHFT SPACE    &mt LCTRL RET  &lt MacNav BSPC  &none   &none
+&kp ESC    &kp N1  &kp N2  &kp N3    &kp N4        &kp N5                                         &kp N6           &kp N7  &kp N8     &kp N9   &kp N0    &kp MINUS
+&kp TAB    &kp Q   &kp W   &kp E     &kp R         &kp T                                          &kp Y            &kp U   &kp I      &kp O    &kp P     &kp LC(TAB)
+&kp LCTRL  &kp A   &kp S   &kp D     &kp F         &kp G                                          &kp H            &kp J   &kp K      &kp L    &kp SEMI  &kp C_PP
+&kp LCTRL  &kp Z   &kp X   &kp C     &kp V         &kp B        &spotlight         &ter_mac       &kp N            &kp M   &kp COMMA  &kp DOT  &kp FSLH  &kp DEL
+                           &kp LALT  &mt LCMD ESC  &mo MacCode  &mt LSHFT SPACE    &mt LCTRL RET  &lt MacNav BSPC  &none   &none
             >;
         };
 
-        MacCode_layer {
+        MacbookCode_layer {
             label = "MacCode";
             display-name = "MacCode";
             bindings = <
-            &trans  &kp F1    &kp F2  &kp F3     &kp F4     &kp F5                       &kp F6     &kp F7    &kp F8    &kp F9    &kp F10        &kp F11
-            &trans  &kp EXCL  &kp AT  &kp HASH   &kp DLLR   &kp PRCNT                    &kp CARET  &kp AMPS  &kp STAR  &kp LPAR  &kp RPAR       &kp F12
-            &trans  &list     &col    &kp GRAVE  &kp MINUS  &kp EQUAL                    &kp LBRC   &kp RBRC  &kp SQT   &kp DQT   &kp LC(TAB)    &none
-            &trans  &tabs     &row    &kp TILDE  &kp PLUS   &kp UNDER  &trans    &trans  &kp LBKT   &kp RBKT  &kp PIPE  &kp BSLH  &kp LG(SPACE)  &kp LG(LS(T))
-                                      &trans     &trans     &trans     &trans    &trans  &trans     &trans    &trans
+&trans  &kp F1    &kp F2  &kp F3     &kp F4     &kp F5                       &kp F6     &kp F7    &kp F8    &kp F9    &kp F10        &kp F11
+&trans  &kp EXCL  &kp AT  &kp HASH   &kp DLLR   &kp PRCNT                    &kp CARET  &kp AMPS  &kp STAR  &kp LPAR  &kp RPAR       &kp F12
+&trans  &list     &col    &kp GRAVE  &kp MINUS  &kp EQUAL                    &kp LBRC   &kp RBRC  &kp SQT   &kp DQT   &kp LC(TAB)    &none
+&trans  &tabs     &row    &kp TILDE  &kp PLUS   &kp UNDER  &trans    &trans  &kp LBKT   &kp RBKT  &kp PIPE  &kp BSLH  &kp LG(SPACE)  &kp LG(LS(T))
+                          &trans     &trans     &trans     &trans    &trans  &trans     &trans    &trans
             >;
         };
 
-        MacNAV_layer {
+        MacbookNAV_layer {
             label = "MacNav";
             display-name = "MacNAV";
             bindings = <
-            &trans  &kp F1              &kp F2         &kp F3         &kp F4    &kp F5                        &kp F6        &kp F7        &kp F8      &kp F9      &kp F10             &kp F11
-            &trans  &kp N1              &kp N2         &kp N3         &kp N4    &kp N5                        &kp N6        &kp N7        &kp N8      &kp N9      &kp N0              &kp F12
-            &trans  &kp LG(LC(LS(N4)))  &kp CAPS       &kp LC(LG(F))  &kp HOME  &kp PG_UP                     &kp LEFT      &kp DOWN      &kp UP      &kp RIGHT   &kp LC(LEFT)        &kp LC(RIGHT)
-            &trans  &ter_mac            &kp LG(SPACE)  &kp LG(M)      &kp END   &kp PG_DN  &trans     &trans  &kp C_VOL_DN  &kp C_VOL_UP  &kp C_PREV  &kp C_NEXT  &kp LG(LC(LS(N5)))  &none
-                                                       &trans         &trans    &to Mouse  &to SYS    &trans  &trans        &trans        &trans
+&trans  &kp F1              &kp F2         &kp F3         &kp F4    &kp F5                        &kp F6        &kp F7        &kp F8      &kp F9      &kp F10             &kp F11
+&trans  &kp N1              &kp N2         &kp N3         &kp N4    &kp N5                        &kp N6        &kp N7        &kp N8      &kp N9      &kp N0              &kp F12
+&trans  &kp LG(LC(LS(N4)))  &kp CAPS       &kp LC(LG(F))  &kp HOME  &kp PG_UP                     &kp LEFT      &kp DOWN      &kp UP      &kp RIGHT   &kp LC(LEFT)        &kp LC(RIGHT)
+&trans  &ter_mac            &kp LG(SPACE)  &kp LG(M)      &kp END   &kp PG_DN  &trans     &trans  &kp C_VOL_DN  &kp C_VOL_UP  &kp C_PREV  &kp C_NEXT  &kp LG(LC(LS(N5)))  &none
+                                           &trans         &trans    &to Mouse  &to SYS    &trans  &trans        &trans        &trans
             >;
         };
 
@@ -252,11 +231,11 @@
             label = "Mouse";
             display-name = "Mouse";
             bindings = <
-            &kp ESC  &none  &none  &none  &none       &none                             &none           &none           &none         &none            &none  &none
-            &none    &none  &none  &none  &none       &none                             &none           &none           &none         &none            &none  &none
-            &none    &none  &none  &none  &none       &none                             &mmv MOVE_LEFT  &mmv MOVE_DOWN  &mmv MOVE_UP  &mmv MOVE_RIGHT  &none  &none
-            &none    &none  &none  &none  &none       &none    &none         &none      &none           &msc SCRL_DOWN  &msc SCRL_UP  &none            &none  &none
-                                   &none  &to MacDef  &to SYS  &to WinDef    &mkp LCLK  &mkp RCLK       &mkp MCLK       &none
+&kp ESC  &none  &none  &none  &none       &none                             &none           &none           &none         &none            &none  &none
+&none    &none  &none  &none  &none       &none                             &none           &none           &none         &none            &none  &none
+&none    &none  &none  &none  &none       &none                             &mmv MOVE_LEFT  &mmv MOVE_DOWN  &mmv MOVE_UP  &mmv MOVE_RIGHT  &none  &none
+&none    &none  &none  &none  &none       &none    &none         &none      &none           &msc SCRL_DOWN  &msc SCRL_UP  &none            &none  &none
+                       &none  &to MacDef  &to SYS  &to WinDef    &mkp LCLK  &mkp RCLK       &mkp MCLK       &none
             >;
         };
 
@@ -264,23 +243,23 @@
             label = "Game";
             display-name = "Game";
             bindings = <
-            &kp ESC    &kp N1     &kp N2  &kp N3   &kp N4  &kp N5                      &none    &none       &none       &none  &none  &none
-            &none      &kp Q      &none   &kp W    &kp E   &kp R                       &none    &none       &none       &none  &none  &none
-            &kp LCTRL  &kp LSHFT  &kp A   &kp S    &kp D   &none                       &none    &none       &none       &none  &none  &none
-            &kp G      &kp N6     &kp N7  &kp N8   &kp N9  &kp N0  &kp B        &none  &none    &none       &none       &none  &none  &none
-                                          &kp TAB  &kp M   &kp Z   &kp SPACE    &none  &to SYS  &to MacDef  &to WinDef
+&kp ESC    &kp N1     &kp N2  &kp N3   &kp N4  &kp N5                      &none    &none       &none       &none  &none  &none
+&none      &kp Q      &none   &kp W    &kp E   &kp R                       &none    &none       &none       &none  &none  &none
+&kp LCTRL  &kp LSHFT  &kp A   &kp S    &kp D   &none                       &none    &none       &none       &none  &none  &none
+&kp G      &kp N6     &kp N7  &kp N8   &kp N9  &kp N0  &kp B        &none  &none    &none       &none       &none  &none  &none
+                              &kp TAB  &kp M   &kp Z   &kp SPACE    &none  &to SYS  &to MacDef  &to WinDef
             >;
         };
 
-        SYS_layer {
+        System_layer {
             label = "SYS";
             display-name = "System";
             bindings = <
-            &none  &none  &none  &none  &none       &bt BT_CLR                        &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4  &none
-            &none  &none  &none  &none  &none       &none                             &none         &none         &none         &none         &none         &none
-            &none  &none  &none  &none  &none       &sys_reset                        &sys_reset    &none         &none         &none         &none         &none
-            &none  &none  &none  &none  &none       &bootloader  &none         &none  &bootloader   &none         &none         &none         &none         &none
-                                 &none  &to MacDef  &to Game     &to WinDef    &none  &none         &none         &none
+&none  &none  &none  &none  &none       &bt BT_CLR                        &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4  &none
+&none  &none  &none  &none  &none       &none                             &none         &none         &none         &none         &none         &none
+&none  &none  &none  &none  &none       &sys_reset                        &sys_reset    &none         &none         &none         &none         &none
+&none  &none  &none  &none  &none       &bootloader  &none         &none  &bootloader   &none         &none         &none         &none         &none
+                     &none  &to MacDef  &to Game     &to WinDef    &none  &none         &none         &none
             >;
         };
     };

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -133,7 +133,7 @@
                 // 開啟 Spotlight
                 <&macro_press>, <&kp LWIN>, <&kp LALT>,
                 <&macro_tap>, <&kp SPACE>,
-                <&macro_release>, <&kp LWIN>, <&kp LALT;
+                <&macro_release>, <&kp LWIN>, <&kp LALT>;
         }; 
 
         col: tmux_column {

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -77,9 +77,10 @@
                 <&macro_release>,
                 <&kp LCMD>,
                 <&macro_pause_for_release>,
-                <&macro_wait_time 150>,
                 <&macro_tap>,
-                <&kp BSPC &kp G &kp H &kp O &kp S &kp T &kp T &kp Y &kp DOT &kp A &kp P &kp P &kp RET>;
+                <&kp G &kp H &kp O &kp S &kp T &kp T &kp Y>,
+                <&macro_wait_time 200>,
+                <&kp RET>;
         };
 
         spotlight: spotlight {

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -31,7 +31,7 @@
         edge: start_edge {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
-            wait-ms = <160>;
+            wait-ms = <0>;
             tap-ms = <0>;
             bindings =
                 <&macro_press>,
@@ -49,7 +49,7 @@
         ter_win: terminal_windows {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
-            wait-ms = <160>;
+            wait-ms = <0>;
             tap-ms = <0>;
             bindings =
                 <&macro_press>,
@@ -67,7 +67,7 @@
         ter_mac: terminal_macos {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
-            wait-ms = <160>;
+            wait-ms = <0>;
             tap-ms = <0>;
             bindings =
                 <&macro_press>,
@@ -85,7 +85,7 @@
         spotlight: spotlight {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
-            wait-ms = <160>;
+            wait-ms = <0>;
             tap-ms = <0>;
             bindings =
                 <&macro_press>,
@@ -99,7 +99,7 @@
         spotlight_win: spotlight_win {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
-            wait-ms = <160>;
+            wait-ms = <0>;
             tap-ms = <0>;
             bindings =
                 <&macro_press>,
@@ -113,7 +113,7 @@
         col: tmux_column {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
-            wait-ms = <160>;
+            wait-ms = <0>;
             tap-ms = <0>;
             bindings = <&macro_tap>, <&kp LC(A) &kp PIPE>;
         };
@@ -121,7 +121,7 @@
         row: tmux_row {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
-            wait-ms = <160>;
+            wait-ms = <0>;
             tap-ms = <0>;
             bindings = <&macro_tap>, <&kp LC(A) &kp MINUS>;
         };
@@ -129,7 +129,7 @@
         list: tmux_list {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
-            wait-ms = <160>;
+            wait-ms = <0>;
             tap-ms = <0>;
             bindings = <&macro_tap>, <&kp LC(A) &kp W>;
         };
@@ -137,7 +137,7 @@
         tabs: tmux_create {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
-            wait-ms = <160>;
+            wait-ms = <0>;
             tap-ms = <0>;
             bindings = <&macro_tap>, <&kp LC(A) &kp C>;
         };

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -31,7 +31,7 @@
         edge: start_edge {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
-            wait-ms = <0>;
+            wait-ms = <160>;
             tap-ms = <0>;
             bindings =
                 <&macro_press>,
@@ -41,15 +41,14 @@
                 <&macro_release>,
                 <&kp LALT>,
                 <&macro_pause_for_release>,
-                <&macro_wait_time 500>,
                 <&macro_tap>,
-                <&kp LS(M) &kp I &kp C &kp R &kp O &kp S &kp O &kp F &kp T &kp SPACE &kp LS(E) &kp D &kp G &kp E &kp RET>;
+                <&kp LS(E) &kp D &kp G &kp E &kp RET>;
         };
 
         ter_win: terminal_windows {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
-            wait-ms = <0>;
+            wait-ms = <160>;
             tap-ms = <0>;
             bindings =
                 <&macro_press>,
@@ -59,9 +58,8 @@
                 <&macro_release>,
                 <&kp LALT>,
                 <&macro_pause_for_release>,
-                <&macro_wait_time 500>,
                 <&macro_tap>,
-                <&kp W &kp T &kp DOT &kp E &kp X &kp E &kp RET>;
+                <&kp W &kp T &kp RET>;
         };
 
         ter_mac: terminal_macos {

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -103,11 +103,11 @@
             tap-ms = <0>;
             bindings =
                 <&macro_press>,
-                <&kp LALT>,
+                <&kp LA(LWIN)>,
                 <&macro_tap>,
                 <&kp SPACE>,
                 <&macro_release>,
-                <&kp LALT>;
+                <&kp LA(LWIN)>;
         };
 
         col: tmux_column {

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -35,11 +35,11 @@
             tap-ms = <0>;
             bindings =
                 <&macro_press>,
-                <&kp LALT>,
+                <&kp LWIN &kp LALT>,
                 <&macro_tap>,
                 <&kp SPACE>,
                 <&macro_release>,
-                <&kp LALT>,
+                <&kp LWIN &kp LALT>,
                 <&macro_pause_for_release>,
                 <&macro_tap>,
                 <&kp E &kp D &kp G &kp E>,
@@ -54,11 +54,11 @@
             tap-ms = <0>;
             bindings =
                 <&macro_press>,
-                <&kp LALT>,
+                <&kp LWIN &kp LALT>,
                 <&macro_tap>,
                 <&kp SPACE>,
                 <&macro_release>,
-                <&kp LALT>,
+                <&kp LWIN &kp LALT>,
                 <&macro_pause_for_release>,
                 <&macro_tap>,
                 <&kp W>, <&kp T>,
@@ -108,11 +108,11 @@
             tap-ms = <0>;
             bindings =
                 <&macro_press>,
-                <&kp LALT>,
+                <&kp LWIN &kp LALT>,
                 <&macro_tap>,
                 <&kp SPACE>,
                 <&macro_release>,
-                <&kp LALT>;
+                <&kp LWIN &kp LALT>;
         };
 
         col: tmux_column {

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -63,7 +63,8 @@
                 <&kp LALT>,
                 <&macro_pause_for_release>,
                 <&macro_tap>,
-                <&kp W &kp T>;
+                <&kp W>, <&kp T>,
+                <&kp RET>;
         };
 
         ter_mac: terminal_macos {

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -41,6 +41,7 @@
                 <&macro_release>,
                 <&kp LALT>,
                 <&macro_pause_for_release>,
+                <&macro_wait_time 250>,
                 <&macro_tap>,
                 <&kp LS(E) &kp D &kp G &kp E &kp RET>;
         };
@@ -58,6 +59,7 @@
                 <&macro_release>,
                 <&kp LALT>,
                 <&macro_pause_for_release>,
+                <&macro_wait_time 250>,
                 <&macro_tap>,
                 <&kp W &kp T &kp RET>;
         };
@@ -65,7 +67,7 @@
         ter_mac: terminal_macos {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
-            wait-ms = <0>;
+            wait-ms = <160>;
             tap-ms = <0>;
             bindings =
                 <&macro_press>,
@@ -75,6 +77,7 @@
                 <&macro_release>,
                 <&kp LCMD>,
                 <&macro_pause_for_release>,
+                <&macro_wait_time 250>,
                 <&macro_tap>,
                 <&kp BSPC &kp G &kp H &kp O &kp S &kp T &kp T &kp Y &kp DOT &kp A &kp P &kp P &kp RET>;
         };
@@ -82,7 +85,7 @@
         spotlight: spotlight {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
-            wait-ms = <0>;
+            wait-ms = <160>;
             tap-ms = <0>;
             bindings =
                 <&macro_press>,
@@ -96,7 +99,7 @@
         spotlight_win: spotlight_win {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
-            wait-ms = <0>;
+            wait-ms = <160>;
             tap-ms = <0>;
             bindings =
                 <&macro_press>,
@@ -110,7 +113,7 @@
         col: tmux_column {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
-            wait-ms = <0>;
+            wait-ms = <160>;
             tap-ms = <0>;
             bindings = <&macro_tap>, <&kp LC(A) &kp PIPE>;
         };
@@ -118,7 +121,7 @@
         row: tmux_row {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
-            wait-ms = <0>;
+            wait-ms = <160>;
             tap-ms = <0>;
             bindings = <&macro_tap>, <&kp LC(A) &kp MINUS>;
         };
@@ -126,7 +129,7 @@
         list: tmux_list {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
-            wait-ms = <0>;
+            wait-ms = <160>;
             tap-ms = <0>;
             bindings = <&macro_tap>, <&kp LC(A) &kp W>;
         };
@@ -134,7 +137,7 @@
         tabs: tmux_create {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
-            wait-ms = <0>;
+            wait-ms = <160>;
             tap-ms = <0>;
             bindings = <&macro_tap>, <&kp LC(A) &kp C>;
         };

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -43,6 +43,7 @@
                 <&macro_pause_for_release>,
                 <&macro_tap>,
                 <&kp E &kp D &kp G &kp E>,
+                <&macro_wait_time 200>,
                 <&kp RET>;
         };
 
@@ -61,7 +62,7 @@
                 <&macro_pause_for_release>,
                 <&macro_tap>,
                 <&kp W>, <&kp T>,
-                <&macro_wait_time 150>,
+                <&macro_wait_time 200>,
                 <&kp RET>;
         };
 
@@ -78,7 +79,7 @@
                 <&macro_release>,
                 <&kp LCMD>,
                 <&macro_pause_for_release>,
-                <&macro_wait_time 150>,
+                <&macro_wait_time 200>,
                 <&macro_tap>,
                 <&kp G &kp H &kp O &kp S &kp T &kp T &kp Y &kp DOT &kp A &kp P &kp P>,
                 <&macro_wait_time 300>,
@@ -107,11 +108,11 @@
             tap-ms = <0>;
             bindings =
                 <&macro_press>,
-                <&kp LWIN &kp LALT>,
+                <&kp LALT>,
                 <&macro_tap>,
                 <&kp SPACE>,
                 <&macro_release>,
-                <&kp LWIN &kp LALT>;
+                <&kp LALT>;
         };
 
         col: tmux_column {

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -53,11 +53,11 @@
             tap-ms = <0>;
             bindings =
                 <&macro_press>,
-                <kp LG(LALT)>,
+                <&kp LG(LALT)>,
                 <&macro_tap>,
                 <&kp SPACE>,
                 <&macro_release>,
-                <kp LG(LALT)>,
+                <&kp LG(LALT)>,
                 <&macro_pause_for_release>,
                 <&macro_wait_time 150>,
                 <&macro_tap>,
@@ -103,11 +103,11 @@
             tap-ms = <0>;
             bindings =
                 <&macro_press>,
-                <kp LG(LALT)>,
+                <&kp LG(LALT)>,
                 <&macro_tap>,
                 <&kp SPACE>,
                 <&macro_release>,
-                <kp LG(LALT)>;
+                <&kp LG(LALT)>;
         };
 
         col: tmux_column {

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -58,16 +58,12 @@
                 <&macro_press>,
                 <&kp LWIN>,
                 <&macro_tap>,
-                <&kp R>,
+                <&kp X>,
                 <&macro_release>,
                 <&kp LWIN>,
                 <&macro_pause_for_release>,
-                <&macro_wait_time 150>,
                 <&macro_tap>,
-                <&kp W &kp T>,
-                <&macro_wait_time 300>,
-                <&macro_tap>,
-                <&kp RET>;
+                <&kp I>;
         };
 
         ter_mac: terminal_macos {
@@ -159,11 +155,11 @@
             label = "WinDef";
             display-name = "Windows";
             bindings = <
-&kp ESC    &kp N1  &kp N2  &kp N3    &kp N4        &kp N5                                         &kp N6           &kp N7  &kp N8     &kp N9   &kp N0    &kp MINUS
-&kp TAB    &kp Q   &kp W   &kp E     &kp R         &kp T                                          &kp Y            &kp U   &kp I      &kp O    &kp P     &kp LC(TAB)
-&kp LCTRL  &kp A   &kp S   &kp D     &kp F         &kp G                                          &kp H            &kp J   &kp K      &kp L    &kp SEMI  &kp C_PP
-&kp LCTRL  &kp Z   &kp X   &kp C     &kp V         &kp B        &spotlight_win     &ter_win       &kp N            &kp M   &kp COMMA  &kp DOT  &kp FSLH  &kp DEL
-                           &kp LWIN  &mt LALT ESC  &mo WinCode  &mt LSHFT SPACE    &mt LCTRL RET  &lt WinNav BSPC  &none   &none
+                &kp ESC    &kp N1  &kp N2  &kp N3    &kp N4        &kp N5                                         &kp N6           &kp N7  &kp N8     &kp N9   &kp N0    &kp MINUS
+                &kp TAB    &kp Q   &kp W   &kp E     &kp R         &kp T                                          &kp Y            &kp U   &kp I      &kp O    &kp P     &kp LC(TAB)
+                &kp LCTRL  &kp A   &kp S   &kp D     &kp F         &kp G                                          &kp H            &kp J   &kp K      &kp L    &kp SEMI  &kp C_PP
+                &kp LCTRL  &kp Z   &kp X   &kp C     &kp V         &kp B        &spotlight_win     &ter_win       &kp N            &kp M   &kp COMMA  &kp DOT  &kp FSLH  &kp DEL
+                                           &kp LWIN  &mt LALT ESC  &mo WinCode  &mt LSHFT SPACE    &mt LCTRL RET  &lt WinNav BSPC  &none   &none
             >;
         };
 
@@ -171,11 +167,11 @@
             label = "WinCode";
             display-name = "WinCode";
             bindings = <
-&trans  &kp F1    &kp F2  &kp F3     &kp F4     &kp F5                       &kp F6     &kp F7    &kp F8    &kp F9    &kp F10     &kp F11
-&trans  &kp EXCL  &kp AT  &kp HASH   &kp DLLR   &kp PRCNT                    &kp CARET  &kp AMPS  &kp STAR  &kp LPAR  &kp RPAR    &kp F12
-&trans  &list     &col    &kp GRAVE  &kp MINUS  &kp EQUAL                    &kp LBRC   &kp RBRC  &kp SQT   &kp DQT   &kp LA(F4)  &kp LC(LG(D))
-&trans  &tabs     &row    &kp TILDE  &kp PLUS   &kp UNDER  &trans    &trans  &kp LBKT   &kp RBKT  &kp PIPE  &kp BSLH  &none       &kp LC(LG(F4))
-                          &trans     &trans     &trans     &trans    &trans  &trans     &trans    &trans
+                &trans  &kp F1    &kp F2  &kp F3     &kp F4     &kp F5                       &kp F6     &kp F7    &kp F8    &kp F9    &kp F10     &kp F11
+                &trans  &kp EXCL  &kp AT  &kp HASH   &kp DLLR   &kp PRCNT                    &kp CARET  &kp AMPS  &kp STAR  &kp LPAR  &kp RPAR    &kp F12
+                &trans  &list     &col    &kp GRAVE  &kp MINUS  &kp EQUAL                    &kp LBRC   &kp RBRC  &kp SQT   &kp DQT   &kp LA(F4)  &kp LC(LG(D))
+                &trans  &tabs     &row    &kp TILDE  &kp PLUS   &kp UNDER  &trans    &trans  &kp LBKT   &kp RBKT  &kp PIPE  &kp BSLH  &none       &kp LC(LG(F4))
+                                          &trans     &trans     &trans     &trans    &trans  &trans     &trans    &trans
             >;
         };
 
@@ -183,11 +179,11 @@
             label = "WinNAV";
             display-name = "WinNAV";
             bindings = <
-&trans  &kp F1         &kp F2    &kp F3        &kp F4    &kp F5                        &kp F6        &kp F7        &kp F8      &kp F9      &kp F10           &kp F11
-&trans  &kp N1         &kp N2    &kp N3        &kp N4    &kp N5                        &kp N6        &kp N7        &kp N8      &kp N9      &kp N0            &kp F12
-&trans  &kp LG(LS(S))  &kp CAPS  &kp LG(UP)    &kp HOME  &kp PG_UP                     &kp LEFT      &kp DOWN      &kp UP      &kp RIGHT   &kp LC(LG(LEFT))  &kp LC(LG(RIGHT))
-&trans  &ter_win       &edge     &kp LG(DOWN)  &kp END   &kp PG_DN  &trans     &trans  &kp C_VOL_DN  &kp C_VOL_UP  &kp C_PREV  &kp C_NEXT  &kp LC(LA(DEL))   &kp DEL
-                                 &trans        &trans    &to Mouse  &to SYS    &trans  &trans        &trans        &trans
+                &trans  &kp F1         &kp F2    &kp F3        &kp F4    &kp F5                        &kp F6        &kp F7        &kp F8      &kp F9      &kp F10           &kp F11
+                &trans  &kp N1         &kp N2    &kp N3        &kp N4    &kp N5                        &kp N6        &kp N7        &kp N8      &kp N9      &kp N0            &kp F12
+                &trans  &kp LG(LS(S))  &kp CAPS  &kp LG(UP)    &kp HOME  &kp PG_UP                     &kp LEFT      &kp DOWN      &kp UP      &kp RIGHT   &kp LC(LG(LEFT))  &kp LC(LG(RIGHT))
+                &trans  &ter_win       &edge     &kp LG(DOWN)  &kp END   &kp PG_DN  &trans     &trans  &kp C_VOL_DN  &kp C_VOL_UP  &kp C_PREV  &kp C_NEXT  &kp LC(LA(DEL))   &kp DEL
+                                                 &trans        &trans    &to Mouse  &to SYS    &trans  &trans        &trans        &trans
             >;
         };
 
@@ -195,11 +191,11 @@
             label = "MacDef";
             display-name = "MacOS";
             bindings = <
-&kp ESC    &kp N1  &kp N2  &kp N3    &kp N4        &kp N5                                         &kp N6           &kp N7  &kp N8     &kp N9   &kp N0    &kp MINUS
-&kp TAB    &kp Q   &kp W   &kp E     &kp R         &kp T                                          &kp Y            &kp U   &kp I      &kp O    &kp P     &kp LC(TAB)
-&kp LCTRL  &kp A   &kp S   &kp D     &kp F         &kp G                                          &kp H            &kp J   &kp K      &kp L    &kp SEMI  &kp C_PP
-&kp LCTRL  &kp Z   &kp X   &kp C     &kp V         &kp B        &spotlight         &ter_mac       &kp N            &kp M   &kp COMMA  &kp DOT  &kp FSLH  &kp DEL
-                           &kp LALT  &mt LCMD ESC  &mo MacCode  &mt LSHFT SPACE    &mt LCTRL RET  &lt MacNav BSPC  &none   &none
+                &kp ESC    &kp N1  &kp N2  &kp N3    &kp N4        &kp N5                                         &kp N6           &kp N7  &kp N8     &kp N9   &kp N0    &kp MINUS
+                &kp TAB    &kp Q   &kp W   &kp E     &kp R         &kp T                                          &kp Y            &kp U   &kp I      &kp O    &kp P     &kp LC(TAB)
+                &kp LCTRL  &kp A   &kp S   &kp D     &kp F         &kp G                                          &kp H            &kp J   &kp K      &kp L    &kp SEMI  &kp C_PP
+                &kp LCTRL  &kp Z   &kp X   &kp C     &kp V         &kp B        &spotlight         &ter_mac       &kp N            &kp M   &kp COMMA  &kp DOT  &kp FSLH  &kp DEL
+                                           &kp LALT  &mt LCMD ESC  &mo MacCode  &mt LSHFT SPACE    &mt LCTRL RET  &lt MacNav BSPC  &none   &none
             >;
         };
 
@@ -207,11 +203,11 @@
             label = "MacCode";
             display-name = "MacCode";
             bindings = <
-&trans  &kp F1    &kp F2  &kp F3     &kp F4     &kp F5                       &kp F6     &kp F7    &kp F8    &kp F9    &kp F10        &kp F11
-&trans  &kp EXCL  &kp AT  &kp HASH   &kp DLLR   &kp PRCNT                    &kp CARET  &kp AMPS  &kp STAR  &kp LPAR  &kp RPAR       &kp F12
-&trans  &list     &col    &kp GRAVE  &kp MINUS  &kp EQUAL                    &kp LBRC   &kp RBRC  &kp SQT   &kp DQT   &kp LC(TAB)    &none
-&trans  &tabs     &row    &kp TILDE  &kp PLUS   &kp UNDER  &trans    &trans  &kp LBKT   &kp RBKT  &kp PIPE  &kp BSLH  &kp LG(SPACE)  &kp LG(LS(T))
-                          &trans     &trans     &trans     &trans    &trans  &trans     &trans    &trans
+                &trans  &kp F1    &kp F2  &kp F3     &kp F4     &kp F5                       &kp F6     &kp F7    &kp F8    &kp F9    &kp F10        &kp F11
+                &trans  &kp EXCL  &kp AT  &kp HASH   &kp DLLR   &kp PRCNT                    &kp CARET  &kp AMPS  &kp STAR  &kp LPAR  &kp RPAR       &kp F12
+                &trans  &list     &col    &kp GRAVE  &kp MINUS  &kp EQUAL                    &kp LBRC   &kp RBRC  &kp SQT   &kp DQT   &kp LC(TAB)    &none
+                &trans  &tabs     &row    &kp TILDE  &kp PLUS   &kp UNDER  &trans    &trans  &kp LBKT   &kp RBKT  &kp PIPE  &kp BSLH  &kp LG(SPACE)  &kp LG(LS(T))
+                                          &trans     &trans     &trans     &trans    &trans  &trans     &trans    &trans
             >;
         };
 
@@ -219,11 +215,11 @@
             label = "MacNav";
             display-name = "MacNAV";
             bindings = <
-&trans  &kp F1              &kp F2         &kp F3         &kp F4    &kp F5                        &kp F6        &kp F7        &kp F8      &kp F9      &kp F10             &kp F11
-&trans  &kp N1              &kp N2         &kp N3         &kp N4    &kp N5                        &kp N6        &kp N7        &kp N8      &kp N9      &kp N0              &kp F12
-&trans  &kp LG(LC(LS(N4)))  &kp CAPS       &kp LC(LG(F))  &kp HOME  &kp PG_UP                     &kp LEFT      &kp DOWN      &kp UP      &kp RIGHT   &kp LC(LEFT)        &kp LC(RIGHT)
-&trans  &ter_mac            &kp LG(SPACE)  &kp LG(M)      &kp END   &kp PG_DN  &trans     &trans  &kp C_VOL_DN  &kp C_VOL_UP  &kp C_PREV  &kp C_NEXT  &kp LG(LC(LS(N5)))  &none
-                                           &trans         &trans    &to Mouse  &to SYS    &trans  &trans        &trans        &trans
+                &trans  &kp F1              &kp F2         &kp F3         &kp F4    &kp F5                        &kp F6        &kp F7        &kp F8      &kp F9      &kp F10             &kp F11
+                &trans  &kp N1              &kp N2         &kp N3         &kp N4    &kp N5                        &kp N6        &kp N7        &kp N8      &kp N9      &kp N0              &kp F12
+                &trans  &kp LG(LC(LS(N4)))  &kp CAPS       &kp LC(LG(F))  &kp HOME  &kp PG_UP                     &kp LEFT      &kp DOWN      &kp UP      &kp RIGHT   &kp LC(LEFT)        &kp LC(RIGHT)
+                &trans  &ter_mac            &kp LG(SPACE)  &kp LG(M)      &kp END   &kp PG_DN  &trans     &trans  &kp C_VOL_DN  &kp C_VOL_UP  &kp C_PREV  &kp C_NEXT  &kp LG(LC(LS(N5)))  &none
+                                                           &trans         &trans    &to Mouse  &to SYS    &trans  &trans        &trans        &trans
             >;
         };
 
@@ -231,11 +227,11 @@
             label = "Mouse";
             display-name = "Mouse";
             bindings = <
-&kp ESC  &none  &none  &none  &none       &none                             &none           &none           &none         &none            &none  &none
-&none    &none  &none  &none  &none       &none                             &none           &none           &none         &none            &none  &none
-&none    &none  &none  &none  &none       &none                             &mmv MOVE_LEFT  &mmv MOVE_DOWN  &mmv MOVE_UP  &mmv MOVE_RIGHT  &none  &none
-&none    &none  &none  &none  &none       &none    &none         &none      &none           &msc SCRL_DOWN  &msc SCRL_UP  &none            &none  &none
-                       &none  &to MacDef  &to SYS  &to WinDef    &mkp LCLK  &mkp RCLK       &mkp MCLK       &none
+                &kp ESC  &none  &none  &none  &none       &none                             &none           &none           &none         &none            &none  &none
+                &none    &none  &none  &none  &none       &none                             &none           &none           &none         &none            &none  &none
+                &none    &none  &none  &none  &none       &none                             &mmv MOVE_LEFT  &mmv MOVE_DOWN  &mmv MOVE_UP  &mmv MOVE_RIGHT  &none  &none
+                &none    &none  &none  &none  &none       &none    &none         &none      &none           &msc SCRL_DOWN  &msc SCRL_UP  &none            &none  &none
+                                       &none  &to MacDef  &to SYS  &to WinDef    &mkp LCLK  &mkp RCLK       &mkp MCLK       &none
             >;
         };
 
@@ -243,11 +239,11 @@
             label = "Game";
             display-name = "Game";
             bindings = <
-&kp ESC    &kp N1     &kp N2  &kp N3   &kp N4  &kp N5                      &none    &none       &none       &none  &none  &none
-&none      &kp Q      &none   &kp W    &kp E   &kp R                       &none    &none       &none       &none  &none  &none
-&kp LCTRL  &kp LSHFT  &kp A   &kp S    &kp D   &none                       &none    &none       &none       &none  &none  &none
-&kp G      &kp N6     &kp N7  &kp N8   &kp N9  &kp N0  &kp B        &none  &none    &none       &none       &none  &none  &none
-                              &kp TAB  &kp M   &kp Z   &kp SPACE    &none  &to SYS  &to MacDef  &to WinDef
+                &kp ESC    &kp N1     &kp N2  &kp N3   &kp N4  &kp N5                      &none    &none       &none       &none  &none  &none
+                &none      &kp Q      &none   &kp W    &kp E   &kp R                       &none    &none       &none       &none  &none  &none
+                &kp LCTRL  &kp LSHFT  &kp A   &kp S    &kp D   &none                       &none    &none       &none       &none  &none  &none
+                &kp G      &kp N6     &kp N7  &kp N8   &kp N9  &kp N0  &kp B        &none  &none    &none       &none       &none  &none  &none
+                                              &kp TAB  &kp M   &kp Z   &kp SPACE    &none  &to SYS  &to MacDef  &to WinDef
             >;
         };
 
@@ -255,11 +251,11 @@
             label = "SYS";
             display-name = "System";
             bindings = <
-&none  &none  &none  &none  &none       &bt BT_CLR                        &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4  &none
-&none  &none  &none  &none  &none       &none                             &none         &none         &none         &none         &none         &none
-&none  &none  &none  &none  &none       &sys_reset                        &sys_reset    &none         &none         &none         &none         &none
-&none  &none  &none  &none  &none       &bootloader  &none         &none  &bootloader   &none         &none         &none         &none         &none
-                     &none  &to MacDef  &to Game     &to WinDef    &none  &none         &none         &none
+                &none  &none  &none  &none  &none       &bt BT_CLR                        &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4  &none
+                &none  &none  &none  &none  &none       &none                             &none         &none         &none         &none         &none         &none
+                &none  &none  &none  &none  &none       &sys_reset                        &sys_reset    &none         &none         &none         &none         &none
+                &none  &none  &none  &none  &none       &bootloader  &none         &none  &bootloader   &none         &none         &none         &none         &none
+                                     &none  &to MacDef  &to Game     &to WinDef    &none  &none         &none         &none
             >;
         };
     };

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -42,9 +42,7 @@
                 <&kp LALT>,
                 <&macro_pause_for_release>,
                 <&macro_tap>,
-                <&kp BSPC &kp DOT &kp E &kp D &kp G &kp E>,
-                <&macro_wait_time 300>,
-                <&kp RET>;
+                <&kp BSPC &kp E &kp D &kp G &kp E &kp RET>;
         };
 
         ter_win: terminal_windows {
@@ -61,9 +59,7 @@
                 <&kp LALT>,
                 <&macro_pause_for_release>,
                 <&macro_tap>,
-                <&kp BSPC &kp DOT &kp W>, <&kp T>,
-                <&macro_wait_time 300>,
-                <&kp RET>;
+                <&kp BSPC &kp W &kp T &kp RET>;
         };
 
         ter_mac: terminal_macos {
@@ -80,10 +76,7 @@
                 <&kp LCMD>,
                 <&macro_pause_for_release>,
                 <&macro_tap>,
-                <&kp BSPC &kp G &kp H &kp O &kp S &kp T &kp T &kp Y &kp DOT &kp A &kp P &kp P>,
-                <&macro_wait_time 300>,
-                <&macro_tap>,
-                <&kp RET>;
+                <&kp BSPC &kp G &kp H &kp O &kp S &kp T &kp T &kp Y &kp DOT &kp A &kp P &kp P &kp RET>;
         };
 
         spotlight: spotlight {

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -41,6 +41,7 @@
                 <&macro_release>,
                 <&kp LALT>,
                 <&macro_pause_for_release>,
+                <&macro_wait_time 500>,
                 <&macro_tap>,
                 <&kp LS(M) &kp I &kp C &kp R &kp O &kp S &kp O &kp F &kp T &kp SPACE &kp LS(E) &kp D &kp G &kp E &kp RET>;
         };
@@ -58,6 +59,7 @@
                 <&macro_release>,
                 <&kp LALT>,
                 <&macro_pause_for_release>,
+                <&macro_wait_time 500>,
                 <&macro_tap>,
                 <&kp W &kp T &kp DOT &kp E &kp X &kp E &kp RET>;
         };

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -171,7 +171,7 @@
             &kp TAB    &kp Q   &kp W   &kp E     &kp R         &kp T                                          &kp Y            &kp U      &kp I      &kp O    &kp P     &kp LC(TAB)
             &kp LCTRL  &kp A   &kp S   &kp D     &kp F         &kp G                                          &kp H            &kp J      &kp K      &kp L    &kp SEMI  &kp C_PP
             &kp LCTRL  &kp Z   &kp X   &kp C     &kp V         &kp B        &kp LC(LS(N2))     &ter_win       &kp N            &kp M      &kp COMMA  &kp DOT  &kp FSLH  &kp DEL
-                                       &kp LWIN  &mt LALT ESC  &mo WinCode  &mt LSHFT SPACE    &mt LCTRL RET  &lt WinNav BSPC  &to Mouse  &to MacDef
+                                       &kp LWIN  &mt LALT ESC  &mo WinCode  &mt LSHFT SPACE    &mt LCTRL RET  &lt WinNav BSPC  &none      &none
             >;
         };
 
@@ -183,7 +183,7 @@
             &trans  &kp EXCL  &kp AT  &kp HASH   &kp DLLR   &kp PRCNT                    &kp CARET  &kp AMPS  &kp STAR  &kp LPAR  &kp RPAR    &kp F12
             &trans  &list     &col    &kp GRAVE  &kp MINUS  &kp EQUAL                    &kp LBRC   &kp RBRC  &kp SQT   &kp DQT   &kp LA(F4)  &kp LC(LG(D))
             &trans  &tabs     &row    &kp TILDE  &kp PLUS   &kp UNDER  &trans    &trans  &kp LBKT   &kp RBKT  &kp PIPE  &kp BSLH  &none       &kp LC(LG(F4))
-                                      &trans     &trans     &trans     &trans    &trans  &trans     &to Game  &to SYS
+                                      &trans     &trans     &trans     &trans    &trans  &trans     &trans    &trans
             >;
         };
 
@@ -191,11 +191,11 @@
             label = "WinNAV";
             display-name = "WinNAV";
             bindings = <
-            &trans  &kp F1         &kp F2    &kp F3        &kp F4    &kp F5                       &kp F6        &kp F7        &kp F8      &kp F9      &kp F10           &kp F11
-            &trans  &kp N1         &kp N2    &kp N3        &kp N4    &kp N5                       &kp N6        &kp N7        &kp N8      &kp N9      &kp N0            &kp F12
-            &trans  &kp LG(LS(S))  &kp CAPS  &kp LG(UP)    &kp HOME  &kp PG_UP                    &kp LEFT      &kp DOWN      &kp UP      &kp RIGHT   &kp LC(LG(LEFT))  &kp LC(LG(RIGHT))
-            &trans  &ter_win       &edge     &kp LG(DOWN)  &kp END   &kp PG_DN  &trans    &trans  &kp C_VOL_DN  &kp C_VOL_UP  &kp C_PREV  &kp C_NEXT  &kp LC(LA(DEL))   &kp DEL
-                                             &trans        &trans    &trans     &trans    &trans  &trans        &trans        &trans
+            &trans  &kp F1         &kp F2    &kp F3        &kp F4    &kp F5                        &kp F6        &kp F7        &kp F8      &kp F9      &kp F10           &kp F11
+            &trans  &kp N1         &kp N2    &kp N3        &kp N4    &kp N5                        &kp N6        &kp N7        &kp N8      &kp N9      &kp N0            &kp F12
+            &trans  &kp LG(LS(S))  &kp CAPS  &kp LG(UP)    &kp HOME  &kp PG_UP                     &kp LEFT      &kp DOWN      &kp UP      &kp RIGHT   &kp LC(LG(LEFT))  &kp LC(LG(RIGHT))
+            &trans  &ter_win       &edge     &kp LG(DOWN)  &kp END   &kp PG_DN  &trans     &trans  &kp C_VOL_DN  &kp C_VOL_UP  &kp C_PREV  &kp C_NEXT  &kp LC(LA(DEL))   &kp DEL
+                                             &trans        &trans    &to Mouse  &to SYS    &trans  &trans        &trans        &trans
             >;
         };
 
@@ -203,11 +203,11 @@
             label = "MacDef";
             display-name = "MacOS";
             bindings = <
-            &kp ESC    &kp N1  &kp N2  &kp N3    &kp N4        &kp N5                                         &kp N6           &kp N7     &kp N8     &kp N9   &kp N0    &kp MINUS
-            &kp TAB    &kp Q   &kp W   &kp E     &kp R         &kp T                                          &kp Y            &kp U      &kp I      &kp O    &kp P     &kp LC(TAB)
-            &kp LCTRL  &kp A   &kp S   &kp D     &kp F         &kp G                                          &kp H            &kp J      &kp K      &kp L    &kp SEMI  &kp C_PP
-            &kp LCTRL  &kp Z   &kp X   &kp C     &kp V         &kp B        &spotlight         &ter_mac       &kp N            &kp M      &kp COMMA  &kp DOT  &kp FSLH  &kp DEL
-                                       &kp LALT  &mt LCMD ESC  &mo MacCode  &mt LSHFT SPACE    &mt LCTRL RET  &lt MacNav BSPC  &to Mouse  &to WinDef
+            &kp ESC    &kp N1  &kp N2  &kp N3    &kp N4        &kp N5                                         &kp N6           &kp N7  &kp N8     &kp N9   &kp N0    &kp MINUS
+            &kp TAB    &kp Q   &kp W   &kp E     &kp R         &kp T                                          &kp Y            &kp U   &kp I      &kp O    &kp P     &kp LC(TAB)
+            &kp LCTRL  &kp A   &kp S   &kp D     &kp F         &kp G                                          &kp H            &kp J   &kp K      &kp L    &kp SEMI  &kp C_PP
+            &kp LCTRL  &kp Z   &kp X   &kp C     &kp V         &kp B        &spotlight         &ter_mac       &kp N            &kp M   &kp COMMA  &kp DOT  &kp FSLH  &kp DEL
+                                       &kp LALT  &mt LCMD ESC  &mo MacCode  &mt LSHFT SPACE    &mt LCTRL RET  &lt MacNav BSPC  &none   &none
             >;
         };
 
@@ -219,7 +219,7 @@
             &trans  &kp EXCL  &kp AT  &kp HASH   &kp DLLR   &kp PRCNT                    &kp CARET  &kp AMPS  &kp STAR  &kp LPAR  &kp RPAR       &kp F12
             &trans  &list     &col    &kp GRAVE  &kp MINUS  &kp EQUAL                    &kp LBRC   &kp RBRC  &kp SQT   &kp DQT   &kp LC(TAB)    &none
             &trans  &tabs     &row    &kp TILDE  &kp PLUS   &kp UNDER  &trans    &trans  &kp LBKT   &kp RBKT  &kp PIPE  &kp BSLH  &kp LG(SPACE)  &kp LG(LS(T))
-                                      &trans     &trans     &trans     &trans    &trans  &trans     &to Game  &to SYS
+                                      &trans     &trans     &trans     &trans    &trans  &trans     &trans    &trans
             >;
         };
 
@@ -227,11 +227,11 @@
             label = "MacNav";
             display-name = "MacNAV";
             bindings = <
-            &trans  &kp F1              &kp F2         &kp F3         &kp F4    &kp F5                       &kp F6        &kp F7        &kp F8      &kp F9      &kp F10             &kp F11
-            &trans  &kp N1              &kp N2         &kp N3         &kp N4    &kp N5                       &kp N6        &kp N7        &kp N8      &kp N9      &kp N0              &kp F12
-            &trans  &kp LG(LC(LS(N4)))  &kp CAPS       &kp LC(LG(F))  &kp HOME  &kp PG_UP                    &kp LEFT      &kp DOWN      &kp UP      &kp RIGHT   &kp LC(LEFT)        &kp LC(RIGHT)
-            &trans  &ter_mac            &kp LG(SPACE)  &kp LG(M)      &kp END   &kp PG_DN  &trans    &trans  &kp C_VOL_DN  &kp C_VOL_UP  &kp C_PREV  &kp C_NEXT  &kp LG(LC(LS(N5)))  &none
-                                                       &trans         &trans    &trans     &trans    &trans  &trans        &trans        &trans
+            &trans  &kp F1              &kp F2         &kp F3         &kp F4    &kp F5                        &kp F6        &kp F7        &kp F8      &kp F9      &kp F10             &kp F11
+            &trans  &kp N1              &kp N2         &kp N3         &kp N4    &kp N5                        &kp N6        &kp N7        &kp N8      &kp N9      &kp N0              &kp F12
+            &trans  &kp LG(LC(LS(N4)))  &kp CAPS       &kp LC(LG(F))  &kp HOME  &kp PG_UP                     &kp LEFT      &kp DOWN      &kp UP      &kp RIGHT   &kp LC(LEFT)        &kp LC(RIGHT)
+            &trans  &ter_mac            &kp LG(SPACE)  &kp LG(M)      &kp END   &kp PG_DN  &trans     &trans  &kp C_VOL_DN  &kp C_VOL_UP  &kp C_PREV  &kp C_NEXT  &kp LG(LC(LS(N5)))  &none
+                                                       &trans         &trans    &to Mouse  &to SYS    &trans  &trans        &trans        &trans
             >;
         };
 
@@ -263,11 +263,11 @@
             label = "SYS";
             display-name = "System";
             bindings = <
-            &none  &none  &none  &none  &none  &bt BT_CLR                   &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4  &none
-            &none  &none  &none  &none  &none  &none                        &none         &none         &none         &none         &none         &none
-            &none  &none  &none  &none  &none  &sys_reset                   &sys_reset    &none         &none         &none         &none         &none
-            &none  &none  &none  &none  &none  &bootloader  &none    &none  &bootloader   &none         &none         &none         &none         &none
-                                 &none  &none  &none        &none    &none  &to Game      &to MacDef    &to WinDef
+            &none  &none  &none  &none  &none       &bt BT_CLR                        &bt BT_SEL 0  &bt BT_SEL 1  &bt BT_SEL 2  &bt BT_SEL 3  &bt BT_SEL 4  &none
+            &none  &none  &none  &none  &none       &none                             &none         &none         &none         &none         &none         &none
+            &none  &none  &none  &none  &none       &sys_reset                        &sys_reset    &none         &none         &none         &none         &none
+            &none  &none  &none  &none  &none       &bootloader  &none         &none  &bootloader   &none         &none         &none         &none         &none
+                                 &none  &to MacDef  &to Game     &to WinDef    &none  &none         &none         &none
             >;
         };
     };

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -61,7 +61,7 @@
                 <&macro_pause_for_release>,
                 <&macro_wait_time 250>,
                 <&macro_tap>,
-                <&kp W &kp T &kp RET>;
+                <&kp W &kp T &kp DOT &kp E &kp X &kp E &kp RET>;
         };
 
         ter_mac: terminal_macos {

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -80,7 +80,7 @@
                 <&kp LCMD>,
                 <&macro_pause_for_release>,
                 <&macro_tap>,
-                <&kp G &kp H &kp O &kp S &kp T &kp T &kp Y &kp DOT &kp A &kp P &kp P>,
+                <&kp BSPC &kp G &kp H &kp O &kp S &kp T &kp T &kp Y &kp DOT &kp A &kp P &kp P>,
                 <&macro_wait_time 300>,
                 <&macro_tap>,
                 <&kp RET>;
@@ -154,11 +154,11 @@
             label = "WinDef";
             display-name = "Windows";
             bindings = <
-                &kp ESC    &kp N1  &kp N2  &kp N3    &kp N4        &kp N5                                         &kp N6           &kp N7  &kp N8     &kp N9   &kp N0    &kp MINUS
-                &kp TAB    &kp Q   &kp W   &kp E     &kp R         &kp T                                          &kp Y            &kp U   &kp I      &kp O    &kp P     &kp LC(TAB)
-                &kp LCTRL  &kp A   &kp S   &kp D     &kp F         &kp G                                          &kp H            &kp J   &kp K      &kp L    &kp SEMI  &kp C_PP
-                &kp LCTRL  &kp Z   &kp X   &kp C     &kp V         &kp B        &spotlight_win     &ter_win       &kp N            &kp M   &kp COMMA  &kp DOT  &kp FSLH  &kp DEL
-                                           &kp LWIN  &mt LALT ESC  &mo WinCode  &mt LSHFT SPACE    &mt LCTRL RET  &lt WinNav BSPC  &none   &none
+                &kp ESC    &kp N1  &kp N2  &kp N3    &kp N4        &kp N5                                          &kp N6           &kp N7  &kp N8     &kp N9   &kp N0    &kp MINUS
+                &kp TAB    &kp Q   &kp W   &kp E     &kp R         &kp T                                           &kp Y            &kp U   &kp I      &kp O    &kp P     &kp LC(TAB)
+                &kp LCTRL  &kp A   &kp S   &kp D     &kp F         &kp G                                           &kp H            &kp J   &kp K      &kp L    &kp SEMI  &kp C_PP
+                &kp LCTRL  &kp Z   &kp X   &kp C     &kp V         &kp B        &kp LS(LC(2))      &spotlight_win  &kp N            &kp M   &kp COMMA  &kp DOT  &kp FSLH  &kp DEL
+                                           &kp LWIN  &mt LALT ESC  &mo WinCode  &mt LSHFT SPACE    &mt LCTRL RET   &lt WinNav BSPC  &none   &none
             >;
         };
 

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -61,6 +61,7 @@
                 <&macro_pause_for_release>,
                 <&macro_tap>,
                 <&kp W>, <&kp T>,
+                <&macro_wait_time 150>,
                 <&kp RET>;
         };
 

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -56,14 +56,14 @@
             tap-ms = <0>;
             bindings =
                 <&macro_press>,
-                <&kp LWIN>,
+                <&kp LALT>,
                 <&macro_tap>,
-                <&kp X>,
+                <&kp SPACE>,
                 <&macro_release>,
-                <&kp LWIN>,
+                <&kp LALT>,
                 <&macro_pause_for_release>,
                 <&macro_tap>,
-                <&kp I>;
+                <&kp W &kp T>;
         };
 
         ter_mac: terminal_macos {

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -167,11 +167,11 @@
             label = "WinDef";
             display-name = "Windows";
             bindings = <
-            &kp ESC    &kp N1  &kp N2  &kp N3    &kp N4        &kp N5                                         &kp N6           &kp N7   &kp N8     &kp N9   &kp N0    &kp MINUS
-            &kp TAB    &kp Q   &kp W   &kp E     &kp R         &kp T                                          &kp Y            &kp U    &kp I      &kp O    &kp P     &kp LC(TAB)
-            &kp LCTRL  &kp A   &kp S   &kp D     &kp F         &kp G                                          &kp H            &kp J    &kp K      &kp L    &kp SEMI  &kp C_PP
-            &kp LCTRL  &kp Z   &kp X   &kp C     &kp V         &kp B        &kp LC(LS(N2))     &ter_win       &kp N            &kp M    &kp COMMA  &kp DOT  &kp FSLH  &kp DEL
-                                       &kp LWIN  &mt LALT ESC  &mo WinCode  &mt LSHFT SPACE    &mt LCTRL RET  &lt WinNav BSPC  &to SYS  &to MacDef
+            &kp ESC    &kp N1  &kp N2  &kp N3    &kp N4        &kp N5                                         &kp N6           &kp N7     &kp N8     &kp N9   &kp N0    &kp MINUS
+            &kp TAB    &kp Q   &kp W   &kp E     &kp R         &kp T                                          &kp Y            &kp U      &kp I      &kp O    &kp P     &kp LC(TAB)
+            &kp LCTRL  &kp A   &kp S   &kp D     &kp F         &kp G                                          &kp H            &kp J      &kp K      &kp L    &kp SEMI  &kp C_PP
+            &kp LCTRL  &kp Z   &kp X   &kp C     &kp V         &kp B        &kp LC(LS(N2))     &ter_win       &kp N            &kp M      &kp COMMA  &kp DOT  &kp FSLH  &kp DEL
+                                       &kp LWIN  &mt LALT ESC  &mo WinCode  &mt LSHFT SPACE    &mt LCTRL RET  &lt WinNav BSPC  &to Mouse  &to MacDef
             >;
         };
 
@@ -182,8 +182,8 @@
             &trans  &kp F1    &kp F2  &kp F3     &kp F4     &kp F5                       &kp F6     &kp F7    &kp F8    &kp F9    &kp F10     &kp F11
             &trans  &kp EXCL  &kp AT  &kp HASH   &kp DLLR   &kp PRCNT                    &kp CARET  &kp AMPS  &kp STAR  &kp LPAR  &kp RPAR    &kp F12
             &trans  &list     &col    &kp GRAVE  &kp MINUS  &kp EQUAL                    &kp LBRC   &kp RBRC  &kp SQT   &kp DQT   &kp LA(F4)  &kp LC(LG(D))
-            &trans  &tabs     &row    &kp TILDE  &kp PLUS   &kp UNDER  &trans    &trans  &kp LBKT   &kp RBKT  &kp PIPE  &kp BSLH  &to Mouse   &kp LC(LG(F4))
-                                      &trans     &trans     &trans     &trans    &trans  &trans     &to Game  &trans
+            &trans  &tabs     &row    &kp TILDE  &kp PLUS   &kp UNDER  &trans    &trans  &kp LBKT   &kp RBKT  &kp PIPE  &kp BSLH  &none       &kp LC(LG(F4))
+                                      &trans     &trans     &trans     &trans    &trans  &trans     &to Game  &to SYS
             >;
         };
 
@@ -203,11 +203,11 @@
             label = "MacDef";
             display-name = "MacOS";
             bindings = <
-            &kp ESC    &kp N1  &kp N2  &kp N3    &kp N4        &kp N5                                         &kp N6           &kp N7   &kp N8     &kp N9   &kp N0    &kp MINUS
-            &kp TAB    &kp Q   &kp W   &kp E     &kp R         &kp T                                          &kp Y            &kp U    &kp I      &kp O    &kp P     &kp LC(TAB)
-            &kp LCTRL  &kp A   &kp S   &kp D     &kp F         &kp G                                          &kp H            &kp J    &kp K      &kp L    &kp SEMI  &kp C_PP
-            &kp LCTRL  &kp Z   &kp X   &kp C     &kp V         &kp B        &spotlight         &ter_mac       &kp N            &kp M    &kp COMMA  &kp DOT  &kp FSLH  &kp DEL
-                                       &kp LALT  &mt LCMD ESC  &mo MacCode  &mt LSHFT SPACE    &mt LCTRL RET  &lt MacNav BSPC  &to SYS  &to WinDef
+            &kp ESC    &kp N1  &kp N2  &kp N3    &kp N4        &kp N5                                         &kp N6           &kp N7     &kp N8     &kp N9   &kp N0    &kp MINUS
+            &kp TAB    &kp Q   &kp W   &kp E     &kp R         &kp T                                          &kp Y            &kp U      &kp I      &kp O    &kp P     &kp LC(TAB)
+            &kp LCTRL  &kp A   &kp S   &kp D     &kp F         &kp G                                          &kp H            &kp J      &kp K      &kp L    &kp SEMI  &kp C_PP
+            &kp LCTRL  &kp Z   &kp X   &kp C     &kp V         &kp B        &spotlight         &ter_mac       &kp N            &kp M      &kp COMMA  &kp DOT  &kp FSLH  &kp DEL
+                                       &kp LALT  &mt LCMD ESC  &mo MacCode  &mt LSHFT SPACE    &mt LCTRL RET  &lt MacNav BSPC  &to Mouse  &to WinDef
             >;
         };
 
@@ -215,11 +215,11 @@
             label = "MacCode";
             display-name = "MacCode";
             bindings = <
-            &trans  &kp F1    &kp F2  &kp F3     &kp F4     &kp F5                       &kp F6     &kp F7         &kp F8    &kp F9    &kp F10      &kp F11
-            &trans  &kp EXCL  &kp AT  &kp HASH   &kp DLLR   &kp PRCNT                    &kp CARET  &kp AMPS       &kp STAR  &kp LPAR  &kp RPAR     &kp F12
-            &trans  &list     &col    &kp GRAVE  &kp MINUS  &kp EQUAL                    &kp LBRC   &kp RBRC       &kp SQT   &kp DQT   &kp LC(TAB)  &none
-            &trans  &tabs     &row    &kp TILDE  &kp PLUS   &kp UNDER  &trans    &trans  &kp LBKT   &kp RBKT       &kp PIPE  &kp BSLH  &to Mouse    &none
-                                      &trans     &trans     &trans     &trans    &trans  &trans     &kp LG(SPACE)  &kp LG(LS(T))
+            &trans  &kp F1    &kp F2  &kp F3     &kp F4     &kp F5                       &kp F6     &kp F7    &kp F8    &kp F9    &kp F10        &kp F11
+            &trans  &kp EXCL  &kp AT  &kp HASH   &kp DLLR   &kp PRCNT                    &kp CARET  &kp AMPS  &kp STAR  &kp LPAR  &kp RPAR       &kp F12
+            &trans  &list     &col    &kp GRAVE  &kp MINUS  &kp EQUAL                    &kp LBRC   &kp RBRC  &kp SQT   &kp DQT   &kp LC(TAB)    &none
+            &trans  &tabs     &row    &kp TILDE  &kp PLUS   &kp UNDER  &trans    &trans  &kp LBKT   &kp RBKT  &kp PIPE  &kp BSLH  &kp LG(SPACE)  &kp LG(LS(T))
+                                      &trans     &trans     &trans     &trans    &trans  &trans     &to Game  &to SYS
             >;
         };
 

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -35,11 +35,11 @@
             tap-ms = <0>;
             bindings =
                 <&macro_press>,
-                <&kp LWIN &kp LALT>,
+                <&kp LALT>,
                 <&macro_tap>,
                 <&kp SPACE>,
                 <&macro_release>,
-                <&kp LWIN &kp LALT>,
+                <&kp LALT>,
                 <&macro_pause_for_release>,
                 <&macro_tap>,
                 <&kp E &kp D &kp G &kp E>,
@@ -54,11 +54,11 @@
             tap-ms = <0>;
             bindings =
                 <&macro_press>,
-                <&kp LWIN &kp LALT>,
+                <&kp LALT>,
                 <&macro_tap>,
                 <&kp SPACE>,
                 <&macro_release>,
-                <&kp LWIN &kp LALT>,
+                <&kp LALT>,
                 <&macro_pause_for_release>,
                 <&macro_tap>,
                 <&kp W>, <&kp T>,

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -42,7 +42,7 @@
                 <&kp LALT>,
                 <&macro_pause_for_release>,
                 <&macro_tap>,
-                <&kp DOT &kp E &kp D &kp G &kp E>,
+                <&kp BSPC &kp DOT &kp E &kp D &kp G &kp E>,
                 <&macro_wait_time 300>,
                 <&kp RET>;
         };
@@ -61,7 +61,7 @@
                 <&kp LALT>,
                 <&macro_pause_for_release>,
                 <&macro_tap>,
-                <&kp DOT &kp W>, <&kp T>,
+                <&kp BSPC &kp DOT &kp W>, <&kp T>,
                 <&macro_wait_time 300>,
                 <&kp RET>;
         };

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -35,15 +35,15 @@
             tap-ms = <0>;
             bindings =
                 <&macro_press>,
-                <&kp LALT>,
+                <&kp LA(LWIN)>,
                 <&macro_tap>,
                 <&kp SPACE>,
                 <&macro_release>,
-                <&kp LALT>,
+                <&kp LA(LWIN)>,
                 <&macro_pause_for_release>,
                 <&macro_wait_time 250>,
                 <&macro_tap>,
-                <&kp LS(E) &kp D &kp G &kp E &kp RET>;
+                <&kp E &kp D &kp G &kp E &kp RET>;
         };
 
         ter_win: terminal_windows {
@@ -53,11 +53,11 @@
             tap-ms = <0>;
             bindings =
                 <&macro_press>,
-                <&kp LALT>,
+                <&kp LA(LWIN)>,
                 <&macro_tap>,
                 <&kp SPACE>,
                 <&macro_release>,
-                <&kp LALT>,
+                <&kp LA(LWIN)>,
                 <&macro_pause_for_release>,
                 <&macro_wait_time 250>,
                 <&macro_tap>,

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -35,11 +35,11 @@
             tap-ms = <0>;
             bindings =
                 <&macro_press>,
-                <&kp LA(LWIN)>,
+                <&kp LG(LALT)>,
                 <&macro_tap>,
                 <&kp SPACE>,
                 <&macro_release>,
-                <&kp LA(LWIN)>,
+                <&kp LG(LALT)>,
                 <&macro_pause_for_release>,
                 <&macro_wait_time 150>,
                 <&macro_tap>,
@@ -53,11 +53,11 @@
             tap-ms = <0>;
             bindings =
                 <&macro_press>,
-                <&kp LA(LWIN)>,
+                <kp LG(LALT)>,
                 <&macro_tap>,
                 <&kp SPACE>,
                 <&macro_release>,
-                <&kp LA(LWIN)>,
+                <kp LG(LALT)>,
                 <&macro_pause_for_release>,
                 <&macro_wait_time 150>,
                 <&macro_tap>,
@@ -103,11 +103,11 @@
             tap-ms = <0>;
             bindings =
                 <&macro_press>,
-                <&kp LA(LWIN)>,
+                <kp LG(LALT)>,
                 <&macro_tap>,
                 <&kp SPACE>,
                 <&macro_release>,
-                <&kp LA(LWIN)>;
+                <kp LG(LALT)>;
         };
 
         col: tmux_column {

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -48,16 +48,6 @@
                 <&kp LC(T)>;
         };
 
-        cal_win: calculator_win {
-            compatible = "zmk,behavior-macro";
-            #binding-cells = <0>;
-            wait-ms = <0>;
-            tap-ms = <0>;
-            bindings =
-                <&macro_tap>,
-                <&kp LG(LC(C))>;
-        };
-
         ptrun: powertoy_run {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
@@ -70,6 +60,16 @@
                 <&kp SPACE>,
                 <&macro_release>,
                 <&kp LG(LALT)>;
+        };
+
+        cal_win: calculator_win {
+            compatible = "zmk,behavior-macro";
+            #binding-cells = <0>;
+            wait-ms = <0>;
+            tap-ms = <0>;
+            bindings =
+                <&macro_tap>,
+                <&kp LG(LC(C))>;
         };
 
         ter_mac: terminal_macos {

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -34,16 +34,8 @@
             wait-ms = <0>;
             tap-ms = <0>;
             bindings =
-                <&macro_press>,
-                <&kp LG(LALT)>,
                 <&macro_tap>,
-                <&kp SPACE>,
-                <&macro_release>,
-                <&kp LG(LALT)>,
-                <&macro_pause_for_release>,
-                <&macro_wait_time 150>,
-                <&macro_tap>,
-                <&kp E &kp D &kp G &kp E &kp RET>;
+                <&kp LC(LS(E))>;
         };
 
         ter_win: terminal_windows {
@@ -58,6 +50,16 @@
                 <&kp T>,
                 <&macro_release>,
                 <&kp LWIN>;
+        };
+
+        cal_win: calculator_win {
+            compatible = "zmk,behavior-macro";
+            #binding-cells = <0>;
+            wait-ms = <0>;
+            tap-ms = <0>;
+            bindings =
+                <&macro_tap>,
+                <&kp LG(LC(C))>;
         };
 
         ter_mac: terminal_macos {

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -35,7 +35,7 @@
             tap-ms = <0>;
             bindings =
                 <&macro_tap>,
-                <&kp LC(LS(E))>;
+                <&kp LC(LS(X))>;
         };
 
         ter_win: terminal_windows {

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -62,6 +62,20 @@
                 <&kp LG(LC(C))>;
         };
 
+        ptrun: powertoy_run {
+            compatible = "zmk,behavior-macro";
+            #binding-cells = <0>;
+            wait-ms = <0>;
+            tap-ms = <0>;
+            bindings =
+                <&macro_press>,
+                <&kp LG(LALT)>,
+                <&macro_tap>,
+                <&kp SPACE>,
+                <&macro_release>,
+                <&kp LG(LALT)>;
+        };
+
         ter_mac: terminal_macos {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
@@ -93,20 +107,6 @@
                 <&kp SPACE>,
                 <&macro_release>,
                 <&kp LCMD>;
-        };
-
-        spotlight_win: spotlight_win {
-            compatible = "zmk,behavior-macro";
-            #binding-cells = <0>;
-            wait-ms = <0>;
-            tap-ms = <0>;
-            bindings =
-                <&macro_press>,
-                <&kp LG(LALT)>,
-                <&macro_tap>,
-                <&kp SPACE>,
-                <&macro_release>,
-                <&kp LG(LALT)>;
         };
 
         col: tmux_column {
@@ -149,11 +149,11 @@
             label = "WinDef";
             display-name = "Windows";
             bindings = <
-                &kp ESC    &kp N1  &kp N2  &kp N3    &kp N4        &kp N5                                          &kp N6           &kp N7  &kp N8     &kp N9   &kp N0    &kp MINUS
-                &kp TAB    &kp Q   &kp W   &kp E     &kp R         &kp T                                           &kp Y            &kp U   &kp I      &kp O    &kp P     &kp LC(TAB)
-                &kp LCTRL  &kp A   &kp S   &kp D     &kp F         &kp G                                           &kp H            &kp J   &kp K      &kp L    &kp SEMI  &kp C_PP
-                &kp LCTRL  &kp Z   &kp X   &kp C     &kp V         &kp B        &kp LS(LC(N2))      &spotlight_win  &kp N            &kp M   &kp COMMA  &kp DOT  &kp FSLH  &kp DEL
-                                           &kp LWIN  &mt LALT ESC  &mo WinCode  &mt LSHFT SPACE    &mt LCTRL RET   &lt WinNav BSPC  &none   &none
+                &kp ESC    &kp N1  &kp N2  &kp N3    &kp N4        &kp N5                                         &kp N6           &kp N7  &kp N8     &kp N9   &kp N0    &kp MINUS
+                &kp TAB    &kp Q   &kp W   &kp E     &kp R         &kp T                                          &kp Y            &kp U   &kp I      &kp O    &kp P     &kp LC(TAB)
+                &kp LCTRL  &kp A   &kp S   &kp D     &kp F         &kp G                                          &kp H            &kp J   &kp K      &kp L    &kp SEMI  &kp C_PP
+                &kp LCTRL  &kp Z   &kp X   &kp C     &kp V         &kp B        &cal_win           &ptrun         &kp N            &kp M   &kp COMMA  &kp DOT  &kp FSLH  &kp DEL
+                                           &kp LWIN  &mt LALT ESC  &mo WinCode  &mt LSHFT SPACE    &mt LCTRL RET  &lt WinNav BSPC  &none   &none
             >;
         };
 
@@ -188,7 +188,7 @@
                 &kp ESC    &kp N1  &kp N2  &kp N3    &kp N4        &kp N5                                         &kp N6           &kp N7  &kp N8     &kp N9   &kp N0    &kp MINUS
                 &kp TAB    &kp Q   &kp W   &kp E     &kp R         &kp T                                          &kp Y            &kp U   &kp I      &kp O    &kp P     &kp LC(TAB)
                 &kp LCTRL  &kp A   &kp S   &kp D     &kp F         &kp G                                          &kp H            &kp J   &kp K      &kp L    &kp SEMI  &kp C_PP
-                &kp LCTRL  &kp Z   &kp X   &kp C     &kp V         &kp B        &spotlight         &ter_mac       &kp N            &kp M   &kp COMMA  &kp DOT  &kp FSLH  &kp DEL
+                &kp LCTRL  &kp Z   &kp X   &kp C     &kp V         &kp B        &spotlight         &spotlight     &kp N            &kp M   &kp COMMA  &kp DOT  &kp FSLH  &kp DEL
                                            &kp LALT  &mt LCMD ESC  &mo MacCode  &mt LSHFT SPACE    &mt LCTRL RET  &lt MacNav BSPC  &none   &none
             >;
         };

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -34,8 +34,23 @@
             wait-ms = <0>;
             tap-ms = <0>;
             bindings =
+                <&macro_press>,
+                <&kp LWIN>,
+                <&kp LALT>,
+
                 <&macro_tap>,
-                <&kp LC(LS(X))>;
+                <&kp SPACE>,
+
+                <&macro_release>,
+                <&kp LWIN>,
+                <&kp LALT>,
+
+                <&macro_wait_time 300>,
+                <&macro_tap>,
+                <&kp E &kp D &kp G &kp E>,
+
+                <&macro_wait_time 100>,
+                <&kp ENTER>;
         };
 
         ter_win: terminal_windows {
@@ -44,8 +59,23 @@
             wait-ms = <0>;
             tap-ms = <0>;
             bindings =
+                <&macro_press>,
+                <&kp LWIN>,
+                <&kp LALT>,
+
                 <&macro_tap>,
-                <&kp LC(T)>;
+                <&kp SPACE>,
+
+                <&macro_release>,
+                <&kp LWIN>,
+                <&kp LALT>,
+
+                <&macro_wait_time 300>,
+                <&macro_tap>,
+                <&kp D &kp E &kp B &kp I &kp A &kp N>,
+
+                <&macro_wait_time 100>,
+                <&kp ENTER>;
         };
 
         ptrun: powertoy_run {
@@ -55,11 +85,15 @@
             tap-ms = <0>;
             bindings =
                 <&macro_press>,
-                <&kp LG(LALT)>,
+                <&kp LWIN>,
+                <&kp LALT>,
+
                 <&macro_tap>,
                 <&kp SPACE>,
+
                 <&macro_release>,
-                <&kp LG(LALT)>;
+                <&kp LWIN>,
+                <&kp LATL>;
         };
 
         cal_win: calculator_win {

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -72,10 +72,7 @@
 
                 <&macro_wait_time 300>,
                 <&macro_tap>,
-                <&kp D &kp E &kp B &kp I &kp A &kp N>,
-
-                <&macro_wait_time 100>,
-                <&kp ENTER>;
+                <&kp W &kp T &kp TAB &kp D &kp ENTER>;
         };
 
         pt_run: powertoy_run {

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -61,7 +61,7 @@
                 <&macro_pause_for_release>,
                 <&macro_wait_time 150>,
                 <&macro_tap>,
-                <&kp W &kp T &kp TAB &kp RET &kp D &kp E &kp B &kp I &kp A &kp N &kp RET>;
+                <&kp W &kp S &kp L &kp RET>;
         };
 
         ter_mac: terminal_macos {

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -53,15 +53,11 @@
             tap-ms = <0>;
             bindings =
                 <&macro_press>,
-                <&kp LG(LALT)>,
+                <&kp LWIN>,
                 <&macro_tap>,
-                <&kp SPACE>,
+                <&kp T>,
                 <&macro_release>,
-                <&kp LG(LALT)>,
-                <&macro_pause_for_release>,
-                <&macro_wait_time 150>,
-                <&macro_tap>,
-                <&kp W &kp S &kp L &kp RET>;
+                <&kp LWIN>;
         };
 
         ter_mac: terminal_macos {

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -78,7 +78,7 @@
                 <&kp ENTER>;
         };
 
-        ptrun: powertoy_run {
+        pt_run: powertoy_run {
             compatible = "zmk,behavior-macro";
             #binding-cells = <0>;
             wait-ms = <0>;
@@ -93,7 +93,7 @@
 
                 <&macro_release>,
                 <&kp LWIN>,
-                <&kp LATL>;
+                <&kp LALT>;
         };
 
         cal_win: calculator_win {
@@ -182,7 +182,7 @@
                 &kp ESC    &kp N1  &kp N2  &kp N3    &kp N4        &kp N5                                         &kp N6           &kp N7  &kp N8     &kp N9   &kp N0    &kp MINUS
                 &kp TAB    &kp Q   &kp W   &kp E     &kp R         &kp T                                          &kp Y            &kp U   &kp I      &kp O    &kp P     &kp LC(TAB)
                 &kp LCTRL  &kp A   &kp S   &kp D     &kp F         &kp G                                          &kp H            &kp J   &kp K      &kp L    &kp SEMI  &kp C_PP
-                &kp LCTRL  &kp Z   &kp X   &kp C     &kp V         &kp B        &cal_win           &ptrun         &kp N            &kp M   &kp COMMA  &kp DOT  &kp FSLH  &kp DEL
+                &kp LCTRL  &kp Z   &kp X   &kp C     &kp V         &kp B        &cal_win           &pt_run        &kp N            &kp M   &kp COMMA  &kp DOT  &kp FSLH  &kp DEL
                                            &kp LWIN  &mt LALT ESC  &mo WinCode  &mt LSHFT SPACE    &mt LCTRL RET  &lt WinNav BSPC  &none   &none
             >;
         };

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -61,7 +61,7 @@
                 <&macro_pause_for_release>,
                 <&macro_wait_time 150>,
                 <&macro_tap>,
-                <&kp W &kp T &kp DOT &kp E &kp X &kp E &kp RET>;
+                <&kp W &kp S &kp L &kp RET>;
         };
 
         ter_mac: terminal_macos {

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -61,7 +61,7 @@
                 <&macro_pause_for_release>,
                 <&macro_wait_time 150>,
                 <&macro_tap>,
-                <&kp W &kp S &kp L &kp RET>;
+                <&kp W &kp T &kp TAB &kp RET &kp D &kp E &kp B &kp I &kp A &kp N &kp RET>;
         };
 
         ter_mac: terminal_macos {

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -44,12 +44,8 @@
             wait-ms = <0>;
             tap-ms = <0>;
             bindings =
-                <&macro_press>,
-                <&kp LWIN>,
                 <&macro_tap>,
-                <&kp T>,
-                <&macro_release>,
-                <&kp LWIN>;
+                <&kp LC(T)>;
         };
 
         cal_win: calculator_win {


### PR DESCRIPTION
style(svg): 修正 SVG 標籤拼寫錯誤並更新鍵位宏
- 透過更新文字內容來修正 SVG 文字標籤中的拼寫錯誤
- 用新的序列取代鍵位配置中的一段按鍵宏序列

Signed-off-by: WSL <39210648+cloverdefa@users.noreply.github.com>

---
Merge branch 'main' into dev (2026-04-15 10:52:14)

---
fix(keymap): 重構並修正鍵位映射以確保一致性與清晰 (#185)

---