### PR TITLE
fix(keyboard-mapping): 更新鍵盤映射設定，將特定鍵位從 LG(LC(F4)) 改為 LG(LC(LEFT))，並將最後一鍵的電源鍵設定為 K_POWER

### DIFF
--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -389,7 +389,7 @@
 &trans  &kp F1     &kp F2  &kp F3  &kp F4  &kp F5                       &kp F6      &kp F7         &kp F8          &kp F9            &kp F10            &kp F11
 &trans  &trans     &trans  &trans  &trans  &trans                       &trans      &trans         &trans          &trans            &trans             &kp F12
 &trans  &trans     &trans  &trans  &trans  &trans                       &trans      &mvd           &mvu            &trans            &trans             &trans
-&trans  &kp LG(I)  &trans  &trans  &trans  &to Mouse  &trans    &trans  &to System  &kp LG(LC(D))  &kp LG(LC(F4))  &kp LG(LC(LEFT))  &kp LG(LC(RIGHT))  &kp C_POWER
+&trans  &kp LG(I)  &trans  &trans  &trans  &to Mouse  &trans    &trans  &to System  &kp LG(LC(D))  &kp LG(LC(F4))  &kp LG(LC(LEFT))  &kp LG(LC(RIGHT))  &kp K_POWER
                            &trans  &trans  &trans     &trans    &trans  &trans      &trans         &trans
             >;
         };


### PR DESCRIPTION
- 更新一行鍵位映射，將鍵從 LG(LC(F4)) 改為 LG(LC(LEFT))
- 將最後一鍵的電源鍵由 C_POWER 改為 K_POWER

Signed-off-by: DAST <39210648+cloverdefa@users.noreply.github.com>